### PR TITLE
critera.md: remove "code coverage" requirements.

### DIFF
--- a/criteria.md
+++ b/criteria.md
@@ -117,8 +117,6 @@ be part of some future "higher-level" badge.
     -   Bug/vulnerability report responsiveness, e.g., commitment to respond to any vulnerability report within (say) 14 days.
 *   Quality:
     -   Continuous integration: Automated test suite applied on each check-in, preferably across many platforms.
-    -   Automated test suite covers >=X% branches of source code (80% considered good).
-    -   Automated test suite covers 100% of branches in source code.  We will *not* add 100% branch coverage to the *basic* set of criteria.  Some projects (like SQLite) do achieve this, but for some projects (such as the Linux kernel) this would be exceptionally difficult to achieve.  Some higher/different related badge *might* add 100% branch coverage.
     -   When a bug is fixed, a regression test is normally added to the automated test suite to prevent its reoccurrence (ideally all).
     -   Reproduceable build.  On rebuilding, the result should be bit-for-bit identical.
     -   Documented test plan.


### PR DESCRIPTION
Code "coverage" is really just "test coverage" and is not a good metric for any sort of "assurance" other than someone wrote a bunch of tests.  See http://martinfowler.com/bliki/TestCoverage.html for more details as to why I wouldn't even put this on a list of something to try to achieve toward.