### PR TITLE
Edits to Reporting

### DIFF
--- a/criteria.md
+++ b/criteria.md
@@ -163,19 +163,17 @@ same as the project URL), and license(s).
 
 *Bug-reporting process*
 
-- <a name="report-url"></a>If an issue tracker is used, please provide its URL. <sup>[<a href="#report-url">report-url</a>]</sup>
-- <a name="report-tracker"></a>It is RECOMMENDED that an issue tracker be used for tracking individual issues. <sup>[<a href="#report-tracker">report-tracker</a>]&#8224;</sup>
 - <a name="report-process"></a>The project MUST provide a process for users to submit bug reports (e.g., using an issue tracker or a mailing list). <sup>[<a href="#report-process">report-process</a>]&#8224;</sup>
-- <a name="report-responses"></a>Developers MUST respond to most bug reports submitted in the last 2-12 months (inclusive); the response need not include a fix. <sup>[<a href="#report-responses">report-responses</a>]&#8224;</sup>
-- <a name="enhancement-responses"></a>Developers SHOULD respond to most enhancement requests in the last 2-12 months (inclusive). Developers MAY choose not to respond. <sup>[<a href="#enhancement-responses">enhancement-responses</a>]&#8224;</sup>
-- <a name="report-archive"></a>Reports and responses MUST be archived for later searching. <sup>[<a href="#report-archive">report-archive</a>]&#8224;</sup>
+- <a name="report-tracker"></a>It is RECOMMENDED that an issue tracker be used for tracking individual issues.  If an issue tracker is used, it MUST be publicly readable and have a URL. <sup>[<a href="#report-tracker">report-tracker</a>]&#8224;</sup>
+- <a name="report-responses"></a>The project MUST respond to most bug reports submitted in the last 2-12 months (inclusive); the response need not include a fix. <sup>[<a href="#report-responses">report-responses</a>]&#8224;</sup>
+- <a name="enhancement-responses"></a>The project SHOULD respond to most enhancement requests in the last 2-12 months (inclusive). The project MAY choose not to respond. <sup>[<a href="#enhancement-responses">enhancement-responses</a>]&#8224;</sup>
+- <a name="report-archive"></a>The project MUST archive reports and responses and be publicly available for later searching. <sup>[<a href="#report-archive">report-archive</a>]&#8224;</sup>
 
-*Vulnerability report process*
+*Vulnerability-reporting process*
 
 - <a name="vulnerability-report-process"></a>The project MUST publish the process for reporting vulnerabilities on the project site (e.g., a clearly designated mailing address on https://PROJECTSITE/security, often security@SOMEWHERE); this MAY be the same as its bug reporting process. <sup>[<a href="#vulnerability-report-process">vulnerability-report-process</a>]&#8224;</sup>
-- <a name="vulnerability-report-private"></a>If private vulnerability reports are supported, the project MUST include how to send the information in a way that is kept private (e.g., a private defect report submitted on the web using TLS or an email encrypted using PGP). If private vulnerability reports are not supported this criterion is automatically met. <sup>[<a href="#vulnerability-report-private">vulnerability-report-private</a>]</sup>
-- <a name="vulnerability-report-response"></a>The project MUST provide an initial reply to a security vulnerability report sent to the project, on average, less than 7 days within the last 6 months.  (If a project is being spammed on its vulnerability report channel, it is okay to only count non-spam messages.) <sup>[<a href="#vulnerability-report-response">vulnerability-report-response</a>]</sup>
-
+- <a name="vulnerability-report-private"></a>If the project supports private vulnerability reports, the project MUST include how to send the information in a way that is kept private (e.g., a private defect report submitted on the web using TLS or an email encrypted using PGP). (If private vulnerability reports are not supported this criterion is automatically met.) <sup>[<a href="#vulnerability-report-private">vulnerability-report-private</a>]</sup>
+- <a name="vulnerability-report-response"></a>The project MUST provide an initial response to a vulnerability report, on average, less than 7 days within the last 6 months.  (If a project is being spammed on its vulnerability report channel, it is okay to only count non-spam messages.) <sup>[<a href="#vulnerability-report-response">vulnerability-report-response</a>]</sup>
 
 ### Quality
 

--- a/criteria.md
+++ b/criteria.md
@@ -163,16 +163,16 @@ same as the project URL), and license(s).
 
 *Bug-reporting process*
 
-- <a name="report-process"></a>The project MUST provide a process for users to submit bug reports (e.g., using an issue tracker or a mailing list). <sup>[<a href="#report-process">report-process</a>]&#8224;</sup>
-- <a name="report-tracker"></a>It is RECOMMENDED that an issue tracker be used for tracking individual issues.  If an issue tracker is used, it MUST be publicly readable and have a URL. <sup>[<a href="#report-tracker">report-tracker</a>]&#8224;</sup>
+- <a name="report-process"></a>The project MUST provide a process for users to submit bug reports (e.g., using an issue tracker or a mailing list). It is RECOMMENDED that an issue tracker be used for tracking individual issues. <sup>[<a href="#report-process">report-process</a>]&#8224;</sup>
+- <a name="report-tracker"></a>If an issue tracker is used, it MUST be publicly readable and have a URL. <sup>[<a href="#report-tracker">report-tracker</a>]&#8224;</sup>
 - <a name="report-responses"></a>The project MUST respond to most bug reports submitted in the last 2-12 months (inclusive); the response need not include a fix. <sup>[<a href="#report-responses">report-responses</a>]&#8224;</sup>
 - <a name="enhancement-responses"></a>The project SHOULD respond to most enhancement requests in the last 2-12 months (inclusive). The project MAY choose not to respond. <sup>[<a href="#enhancement-responses">enhancement-responses</a>]&#8224;</sup>
-- <a name="report-archive"></a>The project MUST archive reports and responses and be publicly available for later searching. <sup>[<a href="#report-archive">report-archive</a>]&#8224;</sup>
+- <a name="report-archive"></a>The project MUST have a publicly available archive for reports and responses for later searching. <sup>[<a href="#report-archive">report-archive</a>]&#8224;</sup>
 
 *Vulnerability-reporting process*
 
 - <a name="vulnerability-report-process"></a>The project MUST publish the process for reporting vulnerabilities on the project site (e.g., a clearly designated mailing address on https://PROJECTSITE/security, often security@SOMEWHERE); this MAY be the same as its bug reporting process. <sup>[<a href="#vulnerability-report-process">vulnerability-report-process</a>]&#8224;</sup>
-- <a name="vulnerability-report-private"></a>If the project supports private vulnerability reports, the project MUST include how to send the information in a way that is kept private (e.g., a private defect report submitted on the web using TLS or an email encrypted using PGP). (If private vulnerability reports are not supported this criterion is automatically met.) <sup>[<a href="#vulnerability-report-private">vulnerability-report-private</a>]</sup>
+- <a name="vulnerability-report-private"></a>If the project supports private vulnerability reports, the project MUST include information on how to send the information in a way that is kept private (e.g., a private defect report submitted on the web using TLS or an email encrypted using PGP). (If private vulnerability reports are not supported this criterion is automatically met.) <sup>[<a href="#vulnerability-report-private">vulnerability-report-private</a>]</sup>
 - <a name="vulnerability-report-response"></a>The project MUST provide an initial response to a vulnerability report, on average, less than 7 days within the last 6 months.  (If a project is being spammed on its vulnerability report channel, it is okay to only count non-spam messages.) <sup>[<a href="#vulnerability-report-response">vulnerability-report-response</a>]</sup>
 
 ### Quality


### PR DESCRIPTION
Attempting to bring consistency of phrases, terms, and formatting to the Reporting section.

I've tried to use the same phrases for the tracking tools as was used in the source control section.  I've made an assumption that the bug reporting tool and archive MUST be publicly visible (which can obviously be changed).