### PR TITLE
DO NOT MERGE...for discussion purposes only

### DIFF
--- a/install-badge-dev-env
+++ b/install-badge-dev-env
@@ -131,7 +131,7 @@ case "$manager" in
     # add_pkg autoconf bison build-essential libssl-dev libyaml-dev \
     #         libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev \
     #         libgdbm3 libgdbm-dev
-    add_pkg rbenv ruby-build ;;
+    add_pkg ruby-build postgresql-server-dev-9.3 cmake ;;
   yum|dnf)
     add_pkg gcc openssl-devel libyaml-devel libffi-devel readline-devel \
             zlib-devel gdbm-devel ncurses-devel ;;
@@ -172,7 +172,10 @@ elif [ "$MYINSTALL_RBENV" != 'yes' ] ; then
   echo 'Skipping rbenv install.'
 else
   echo 'Downloading and installing rbenv from GitHub' >&2
-  git clone https://github.com/sstephenson/rbenv.git ~/.rbenv
+  git clone git@github.com:rbenv/rbenv.git ~/.rbenv
+  cd ~/.rbenv
+  git checkout 3997a394d975136f468be196941492d3d0ef5143
+  cd -
 fi
 
 if [ "$MYINSTALL_RBENV" = 'yes' ] ; then
@@ -238,6 +241,7 @@ if [ "$MYINSTALL_RBENV" = 'yes' ] && is_command rbenv ; then
   echo "Using rbenv to locally install ruby version ${ruby_version}"
   rbenv install --skip-existing "$ruby_version"
   rbenv local "$ruby_version" # In this directory AND BELOW, use this version.
+  eval "$(rbenv init -)"
 else
   echo 'Skipped installing fixed version of ruby - no rbenv'
 fi


### PR DESCRIPTION
I am seeing the following error still at Stage 6 (the db_present assignment line):

    /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:80:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'uglifier'. (Bundler::GemRequireError)
        from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
        from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:72:in `each'
        from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:72:in `block in require'
        from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:61:in `each'
        from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:61:in `require'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler.rb:99:in `require'
       from /home/dale/Git/cii-best-practices-badge/config/application.rb:7:in `<top (required)>'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/application.rb:82:in `require'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/application.rb:82:in `preload'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/application.rb:143:in `serve'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/application.rb:131:in `block in run'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/application.rb:125:in `loop'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/application.rb:125:in `run'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/application/boot.rb:18:in `<top (required)>'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
       from /home/dale/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
       from -e:1:in `<main>'
