### PR TITLE
Create Criteria class

### DIFF
--- a/app/models/criteria.rb
+++ b/app/models/criteria.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+class Criteria
+  class << self
+    include Enumerable
+    alias length count
+    alias size count
+  end
+
+  # CriteriaHash is loaded during application initialization
+  # from the criteria.yml YAML file
+
+  ALL_CRITERIA = CriteriaHash.keys.map(&:to_sym).freeze
+  ALL_ACTIVE_CRITERIA = ALL_CRITERIA.reject do |criterion|
+    CriteriaHash[criterion]['category'] == 'FUTURE'
+  end.freeze
+
+  # Create recursive class methods for each criterion
+  # Criteria name is a singleton class method on Criteria
+  # Criteria attributes use an OpenStruct to respond to methods
+  ALL_CRITERIA.each do |criterion|
+    define_singleton_method(criterion) do
+      OpenStruct.new(CriteriaHash[criterion])
+    end
+  end
+
+  def self.each
+    # Each method is required for Criteria to use class-level Enumerable mixin
+    ALL_CRITERIA.each do |criterion|
+      yield criterion
+    end
+    self
+  end
+
+  def self.keys
+    ALL_CRITERIA
+  end
+
+  def self.to_h
+    CriteriaHash
+  end
+
+  def self.criterion_category(criterion)
+    # Is this criterion in the category MUST, SHOULD, or SUGGESTED?
+    send(criterion).category
+  end
+
+  def self.na_allowed?(criterion)
+    send(criterion).na_allowed
+  end
+
+  def self.met_url_required?(criterion)
+    # Is a URL required in the justification to be enough with met?
+    send(criterion).met_url_required
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,37 +6,13 @@ class Project < ActiveRecord::Base
   MAX_TEXT_LENGTH = 8192 # Arbitrary maximum to reduce abuse
   MAX_SHORT_STRING_LENGTH = 254 # Arbitrary maximum to reduce abuse
 
-  # The "Criteria" hash is loaded during application initialization
-  # from a YAML file.
-
-  ALL_CRITERIA = Criteria.keys.map(&:to_sym).freeze
-  ALL_ACTIVE_CRITERIA = ALL_CRITERIA.reject do |criterion|
-    Criteria[criterion][:category] == 'FUTURE'
-  end.freeze
-  ALL_CRITERIA_STATUS = ALL_CRITERIA.map(&:status).freeze
-  ALL_CRITERIA_JUSTIFICATION = ALL_CRITERIA.map(&:justification).freeze
   PROJECT_OTHER_FIELDS = %i(name description project_homepage_url repo_url cpe
                             license general_comments user_id).freeze
+  ALL_CRITERIA_STATUS = Criteria::ALL_CRITERIA.map(&:status).freeze
+  ALL_CRITERIA_JUSTIFICATION = Criteria::ALL_CRITERIA.map(&:justification)
+                                                     .freeze
   PROJECT_PERMITTED_FIELDS = (PROJECT_OTHER_FIELDS + ALL_CRITERIA_STATUS +
                               ALL_CRITERIA_JUSTIFICATION).freeze
-
-  # TODO: Remove these Criteria queries from the project model
-  # Note: These are up top because they must be defined before use
-
-  # Is this criterion in the category MUST, SHOULD, or SUGGESTED?
-  def self.criterion_category(criterion)
-    (Criteria[criterion])[:category]
-  end
-
-  # Is a URL required in the justification to be enough with met?
-  def self.met_url_required?(criterion)
-    (Criteria[criterion])[:met_url_required]
-  end
-
-  # Is na allowed?
-  def self.na_allowed?(criterion)
-    (Criteria[criterion])[:na_allowed]
-  end
 
   # A project is associated with a user
   belongs_to :user
@@ -73,8 +49,8 @@ class Project < ActiveRecord::Base
   validates :user_id, presence: true
 
   # Validate all of the criteria-related inputs
-  ALL_CRITERIA.each do |criterion|
-    if na_allowed?(criterion)
+  Criteria::ALL_CRITERIA.each do |criterion|
+    if Criteria.na_allowed?(criterion)
       validates criterion.status, inclusion: { in: STATUS_CHOICE_NA }
     else
       validates criterion.status, inclusion: { in: STATUS_CHOICE }
@@ -92,20 +68,20 @@ class Project < ActiveRecord::Base
   end
 
   def badge_percentage
-    met = ALL_ACTIVE_CRITERIA.count { |criterion| passing? criterion }
-    to_percentage met, ALL_ACTIVE_CRITERIA.length
+    met = Criteria::ALL_ACTIVE_CRITERIA.count { |criterion| passing? criterion }
+    to_percentage met, Criteria::ALL_ACTIVE_CRITERIA.length
   end
 
   private
 
   def any_status_in_progress?
-    ALL_ACTIVE_CRITERIA.any? do |criterion|
+    Criteria::ALL_ACTIVE_CRITERIA.any? do |criterion|
       self[criterion.status] == '?' || self[criterion.status].blank?
     end
   end
 
   def all_active_criteria_passing?
-    ALL_ACTIVE_CRITERIA.all? { |criterion| passing? criterion }
+    Criteria::ALL_ACTIVE_CRITERIA.all? { |criterion| passing? criterion }
   end
 
   def contains_url?(text)
@@ -117,8 +93,8 @@ class Project < ActiveRecord::Base
   def passing?(criterion)
     status = self[criterion.status]
     justification = self[criterion.justification]
-    category = Project.criterion_category(criterion)
-    met_needs_url = Project.met_url_required?(criterion)
+    category = Criteria.criterion_category(criterion)
+    met_needs_url = Criteria.met_url_required?(criterion)
 
     return true if category == 'FUTURE'
     return true if status == 'N/A'

--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -1,4 +1,4 @@
-    <div id="<%= criterion %>" class="row"><% raise unless criterion && Criteria[criterion] %>
+    <div id="<%= criterion %>" class="row"><% raise unless criterion && Criteria.send(criterion) %>
       <% status_symbol = (criterion + "_status").to_sym %>
       <% justification_symbol = (criterion + "_justification").to_sym %>
 
@@ -6,8 +6,8 @@
       <% crypto_class = is_crypto ? ' criterion-is-crypto' : '' %>
 
       <%# A criterion_category is 'MUST' | 'SHOULD' | 'SUGGESTED' | 'FUTURE' %>
-      <% criterion_category = Project.criterion_category(criterion) %>
-      <% criterion_met_url_required = Project.met_url_required?(criterion) %>
+      <% criterion_category = Criteria.criterion_category(criterion) %>
+      <% criterion_met_url_required = Criteria.met_url_required?(criterion) %>
 
       <div class="col-md-2 criteria-radio<%= crypto_class %>">
        <div class="row status-chooser">
@@ -26,7 +26,7 @@
          <div class="col-xs-3 text-center block-center">
              <%= f.radio_button status_symbol, 'Unmet', inline: true, disabled: is_disabled  %><br><br>Unmet
          </div>
-         <% if Project.na_allowed?(criterion) %>
+         <% if Criteria.na_allowed?(criterion) %>
          <div class="col-xs-2 text-center block-center">
              <%= f.radio_button status_symbol, 'N/A', inline: true, disabled: is_disabled  %><br><br>&nbsp;N/A&nbsp;
          </div>
@@ -43,21 +43,21 @@
           <% if criterion_category == 'FUTURE' %>
           (Future criterion)
           <% end %>
-          <%= raw Criteria[criterion][:description] %>
+          <%= sanitize Criteria.send(criterion).description %>
           <% if criterion_met_url_required %>
             (URL required)
           <% end %>
           <sup>[<%= criterion %>]</sup>
-          <%= if Criteria[criterion][:details]
+          <%= if Criteria.send(criterion).details
               render(partial: "details", locals: {f: f,
                        criterion: criterion,
-                       details: Criteria[criterion]['details']})
+                       details: Criteria.send(criterion).details})
              end %>
          <div id="<%= criterion + '_met_placeholder' %>" class="hidden">
-          <%= if Criteria[criterion][:met_placeholder]
-                raw Criteria[criterion][:met_placeholder]
+          <%= if Criteria.send(criterion).met_placeholder
+                raw Criteria.send(criterion).met_placeholder
               else
-                if Criteria[criterion][:met_url]
+                if Criteria.send(criterion).met_url
                   raw "(URL required) Please explain how this is met, including 1+ key URLs."
                 else
                   raw "(Optional) Please explain how this is met, including 1+ key URLs."
@@ -65,20 +65,20 @@
               end %>
          </div>
          <div id="<%= criterion + '_unmet_placeholder' %>" class="hidden">
-          <%= raw (Criteria[criterion][:unmet_placeholder] ||
+          <%= sanitize (Criteria.send(criterion).unmet_placeholder ||
                  "Please explain why it's okay this is unmet, including 1+ key URLs.") %>
          </div>
          <div id="<%= criterion + '_na_placeholder' %>" class="hidden">
-          <%= raw (Criteria[criterion][:na_placeholder] ||
+          <%= sanitize (Criteria.send(criterion).na_placeholder ||
                  "(Optional) Please explain why this is not applicable (N/A), including 1+ key URLs." ) %>
          </div>
-         <% if Criteria[criterion][:met_suppress] %>
+         <% if Criteria.send(criterion).met_suppress %>
            <div id="<%= criterion + '_met_suppress' %>" class="hidden"></div>
          <% end %>
-         <% if Criteria[criterion][:unmet_suppress] %>
+         <% if Criteria.send(criterion).unmet_suppress %>
            <div id="<%= criterion + '_unmet_suppress' %>" class="hidden"></div>
          <% end %>
-         <% if Criteria[criterion][:na_suppress] %>
+         <% if Criteria.send(criterion).na_suppress %>
            <div id="<%= criterion + '_na_suppress' %>" class="hidden"></div>
          <% end %>
          <% if (is_disabled) %>

--- a/config/initializers/criteria.rb
+++ b/config/initializers/criteria.rb
@@ -1,2 +1,3 @@
 require 'yaml'
-Criteria = YAML.load(File.open('criteria.yml')).with_indifferent_access.freeze
+CriteriaHash = YAML.load(File.open('criteria.yml')).with_indifferent_access
+                   .freeze

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -25,6 +25,8 @@ RemoveTrailingWhitespaceCheck: { }
 RemoveUnusedMethodsInControllersCheck: { except_methods: [] }
 RemoveUnusedMethodsInHelpersCheck: { except_methods: [] }
 RemoveUnusedMethodsInModelsCheck: { except_methods: [
+  'Criteria#size',
+  'Criteria#to_h',
   'User#digest'
   ] }
 ReplaceComplexCreationWithFactoryMethodCheck: { attribute_assignment_count: 2 }

--- a/test/integration/users_manipulate_project_test.rb
+++ b/test/integration/users_manipulate_project_test.rb
@@ -28,7 +28,7 @@ class UsersManipulateProjectTest < ActionDispatch::IntegrationTest
 
       # Check to ensure that the form includes all the criteria, but only once.
       # This could fail if the view incorrectly omits or duplicates one.
-      Criteria.each_key do |criterion|
+      Criteria.each do |criterion|
         assert_select "##{criterion}" # Check for existence
         assert_select "##{criterion}" do |elements|
           assert_equal 1, elements.count # Check for duplication

--- a/test/models/criteria_test.rb
+++ b/test/models/criteria_test.rb
@@ -6,15 +6,15 @@ class CriteriaTest < ActiveSupport::TestCase
   end
 
   test 'Criteria should have floss_license_osi' do
-    assert Criteria[:floss_license_osi]
+    assert Criteria.floss_license_osi
   end
 
   test 'Criteria "contribution" is in the category MUST' do
-    assert_equal 'MUST', Criteria[:contribution][:category]
+    assert_equal 'MUST', Criteria.contribution.category
   end
 
   test 'Criteria "contribution_requirements" is in the category SHOULD' do
-    assert_equal 'SHOULD', Criteria[:contribution_requirements][:category]
+    assert_equal 'SHOULD', Criteria.contribution_requirements.category
   end
 
   test 'Ensure that only allowed fields are in Criteria' do
@@ -23,7 +23,7 @@ class CriteriaTest < ActiveSupport::TestCase
                            :met_placeholder, :unmet_placeholder,
                            :na_placeholder,
                            :met_suppress, :unmet_suppress, :autofill]
-    Criteria.each do |_criterion, values|
+    Criteria.to_h.each do |_criterion, values|
       values.each do |key, _value|
         assert_includes allowed_set, key.to_sym
       end
@@ -32,7 +32,7 @@ class CriteriaTest < ActiveSupport::TestCase
 
   test 'Ensure that required fields are in Criteria' do
     required_set = Set.new [:category, :description]
-    Criteria.each do |_criterion, values|
+    Criteria.to_h.each do |_criterion, values|
       required_set.each do |required_field|
         assert_includes values.keys, required_field.to_s
       end
@@ -40,14 +40,14 @@ class CriteriaTest < ActiveSupport::TestCase
   end
 
   test 'Ensure only valid categories in Criteria' do
-    Criteria.each do |_criterion, values|
+    Criteria.to_h.each do |_criterion, values|
       allowed_field_values = %w(MUST SHOULD SUGGESTED FUTURE)
       assert_includes allowed_field_values, values['category']
     end
   end
 
   test 'If URL required, do not suppress justification' do
-    Criteria.each do |_criterion, values|
+    Criteria.to_h.each do |_criterion, values|
       assert_not values[:met_url_required] && values[:met_suppress]
     end
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -50,7 +50,7 @@ class UserTest < ActiveSupport::TestCase
 
   test 'emails should be unique' do
     duplicate_user = @user.dup
-    @user.save
+    @user.save!
     assert_not duplicate_user.valid?
   end
 
@@ -65,7 +65,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'associated projects should be destroyed' do
-    @user.save
+    @user.save!
     @user.projects.create!(project_homepage_url: 'https://www.example.org',
                            repo_url: 'https://www.example.org/code')
     assert_difference 'Project.count', -1 do


### PR DESCRIPTION
@david-a-wheeler 

Please review how I created a non-ActiveRecord Criteria class to make the content of criteria.yml available through methods, rather than hashes.

Easiest to review is https://github.com/linuxfoundation/cii-best-practices-badge/compare/dan-refactor...dan-criteria-class?expand=1 which shows the difference from the project refactor (on which I'll comment separately).

The part I was unclear on was where I replaced `raw` with `sanitize` to satisfy Brakeman. It seems like if that works, we should do it everywhere, but I don't know why Brakeman didn't complain everywhere.