### PR TITLE
Use fork of eslintrb to avoid error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'bundler-audit', '0.5.0'
   gem 'ruby-graphviz', '1.2.2'
   gem 'dotenv-rails', '2.1.1'
+  gem 'eslintrb', github: 'dankohn/eslintrb', ref: '306932f'
   gem 'license_finder'
   gem 'mdl', '0.3.1'
   gem 'pronto', '0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/dankohn/eslintrb.git
+  revision: 306932f332bc7fe611e2e1cbea5ede64afeac551
+  ref: 306932f
+  specs:
+    eslintrb (2.0.2)
+      execjs
+      multi_json (>= 1.3)
+      rake
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -117,10 +127,6 @@ GEM
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
-    eslintrb (2.0.3)
-      execjs
-      multi_json (>= 1.3)
-      rake
     execjs (2.6.0)
     faker (1.6.3)
       i18n (~> 0.5)
@@ -455,6 +461,7 @@ DEPENDENCIES
   chromedriver-helper (= 1.0.0)
   coveralls (= 0.8.13)
   dotenv-rails (= 2.1.1)
+  eslintrb!
   faker (= 1.6.3)
   fasterer (= 0.3.2)
   fastly-rails (= 0.5.0)

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -195,21 +195,21 @@ Rails::TestTask.new('test:features' => 'test:prepare') do |t|
   t.pattern = 'test/features/**/*_test.rb'
 end
 
-# # Eslint rake configuration per https://github.com/ocke/eslintrb
-# # Unfortunately, this will cause rake 11.* to complain as follows:
-# #   [DEPRECATION] `last_comment` is deprecated.
-# #   Please use `last_description` instead.
-# # The warning is not caused by our gem, and does not affect our
-# # executable, so we don't plan to change it.
-# require 'eslintrb/eslinttask'
-# Eslintrb::EslintTask.new :eslint do |t|
-#   # We only examine one Javascript file.  This would examine all of them,
-#   # but the ESLint parser fails on comment-only files:
-#   # t.pattern = 'app/assets/javascripts/**/*.js'
-#   t.pattern = 'app/assets/javascripts/*.js'
-#   t.exclude_pattern =
-#     'app/assets/javascripts/{application,imagesloaded.pkgd}.js'
-#   t.options = :eslintrc
-# end
+# Eslint rake configuration per https://github.com/ocke/eslintrb
+# Unfortunately, this will cause rake 11.* to complain as follows:
+#   [DEPRECATION] `last_comment` is deprecated.
+#   Please use `last_description` instead.
+# The warning is not caused by our gem, and does not affect our
+# executable, so we don't plan to change it.
+require 'eslintrb/eslinttask'
+Eslintrb::EslintTask.new :eslint do |t|
+  # We only examine one Javascript file.  This would examine all of them,
+  # but the ESLint parser fails on comment-only files:
+  # t.pattern = 'app/assets/javascripts/**/*.js'
+  t.pattern = 'app/assets/javascripts/*.js'
+  t.exclude_pattern =
+    'app/assets/javascripts/{application,imagesloaded.pkgd}.js'
+  t.options = :eslintrc
+end
 
 Rake::Task['test:run'].enhance ['test:features']


### PR DESCRIPTION
@david-a-wheeler 
```bash
$ rake eslint
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
```
This was causing a failure in Heroku deploys with these errors:
```bash
remote:        Bundle completed (0.48s)
remote:        Cleaning up the bundler cache.
remote: sh: 2: Syntax error: Unterminated quoted string
remote: sh: 2: Syntax error: Unterminated quoted string
remote:  !
remote:  !     Could not detect rake tasks
remote:  !     ensure you can run `$ bundle exec rake -P` against your app
remote:  !     and using the production group of your Gemfile.
remote:  !     rake aborted!
remote:  !     LoadError: cannot load such file -- eslintrb/eslinttask
```