### PR TITLE
Dan 310 pull database

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -9,8 +9,8 @@
 <div class="center">
 <h2>Projects</h2>
   <%= search_form_for @search do |f| %>
-      <%# <%= f.label :badge_status_eq %>
-      <%# <%= f.collection_select(:badge_status_eq,
+      <%= f.label :badge_status_eq %>
+      <%= f.collection_select(:badge_status_eq,
                               Project::BADGE_STATUS_CHOICE, :id, :name) %>
       <%= f.label(:name_or_homepage_url_or_repo_url_start,
                   "Name or URLs begin with") %>

--- a/db/migrate/20160501143232_add_badge_status_to_projects.rb
+++ b/db/migrate/20160501143232_add_badge_status_to_projects.rb
@@ -4,7 +4,7 @@ class AddBadgeStatusToProjects < ActiveRecord::Migration
     add_index :projects, :badge_status
     Project.find_each do |project|
       project.update_badge_status
-      project.save(validate: false)
+      project.save!(validate: false)
     end
   end
 

--- a/db/migrate/20160501143232_add_badge_status_to_projects.rb
+++ b/db/migrate/20160501143232_add_badge_status_to_projects.rb
@@ -4,7 +4,7 @@ class AddBadgeStatusToProjects < ActiveRecord::Migration
     add_index :projects, :badge_status
     Project.find_each do |project|
       project.update_badge_status
-      project.save!
+      project.save(validate: false)
     end
   end
 

--- a/db/migrate/20160503195329_add_stats_extension.rb
+++ b/db/migrate/20160503195329_add_stats_extension.rb
@@ -1,0 +1,5 @@
+class AddStatsExtension < ActiveRecord::Migration
+  def change
+    enable_extension 'pg_stat_statements'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160501224428) do
+ActiveRecord::Schema.define(version: 20160503195329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -193,7 +193,7 @@ namespace :fastly do
   end
 end
 
-desc 'Copy database from production into development (requires access privs)'
+desc 'Drop development database'
 task :drop_database do
   puts 'Dropping database development'
   # Command from http://stackoverflow.com/a/13245265/1935918


### PR DESCRIPTION
@david-a-wheeler @dwvisser 

I believe the problems on master were caused by invalid data that caused the migration https://github.com/linuxfoundation/cii-best-practices-badge/blob/master/db/migrate/20160501143232_add_badge_status_to_projects.rb#L7 to fail.

Specifically, when I run `rake pull_master` I get:
```bash
g_restore: setting owner and privileges for INDEX "public.index_users_on_uid"
pg_restore: setting owner and privileges for INDEX "public.index_versions_on_item_type_and_item_id"
pg_restore: setting owner and privileges for INDEX "public.unique_schema_migrations"
pg_restore: setting owner and privileges for FK CONSTRAINT "public.fk_rails_b872a6760a"
== 20160501143232 AddBadgeStatusToProjects: migrating =========================
-- add_column(:projects, :badge_status, :string)
   -> 0.0019s
-- add_index(:projects, :badge_status)
   -> 0.0180s
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Validation failed: Repo url has already been taken
/Users/dan/Dropbox/Documents/dev/cii-best-practices-badge/db/migrate/20160501143232_add_badge_status_to_projects.rb:7:in `block in up'
/Users/dan/Dropbox/Documents/dev/cii-best-practices-badge/db/migrate/20160501143232_add_badge_status_to_projects.rb:5:in `up'
/Users/dan/Dropbox/Documents/dev/cii-best-practices-badge/lib/tasks/default.rake:223:in `block in <top (required)>'
ActiveRecord::RecordInvalid: Validation failed: Repo url has already been taken
/Users/dan/Dropbox/Documents/dev/cii-best-practices-badge/db/migrate/20160501143232_add_badge_status_to_projects.rb:7:in `block in up'
/Users/dan/Dropbox/Documents/dev/cii-best-practices-badge/db/migrate/20160501143232_add_badge_status_to_projects.rb:5:in `up'
/Users/dan/Dropbox/Documents/dev/cii-best-practices-badge/lib/tasks/default.rake:223:in `block in <top (required)>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

The fix is to re-save the project records without validating, so as to avoid the repo_url uniqueness constraint.

Of course, to get this far, I had to implement the `rake pull_master`, which I hope you agree is cleaner than restoring from a temp file.

Also, I added a migration to add `pg_stat_statement` since Heroku uses it, so that the schema of the downloaded database will match what you get from `db:reset`.

Finally, @david-a-wheeler once you're convinced master is working and this is ready to merge (at least to staging), I would recommend copying the production database to staging and master to avoid dealing with invalid databases.