### PR TITLE
Inline SVGs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'fastly-rails', '0.5.0' # Use Fastly CDN
 gem 'font-awesome-rails', '4.6.1.0'
 gem 'github_api', '0.13.1'
 gem 'imagesLoaded_rails', '4.1.0' # Javascript - enable wait for image load
+gem 'inline_svg', '0.7.0'
 gem 'jbuilder', '2.4.1'
 gem 'jquery-rails', '4.1.1' # Javascript jQuery library (for Rails)
 gem 'jquery-ui-rails', '5.0.5' # Javascript jQueryUI library (for Rails)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,10 @@ GEM
     i18n (0.7.0)
     imagesLoaded_rails (4.1.0)
       railties (>= 3.1)
+    inline_svg (0.7.0)
+      activesupport (>= 4.0.4)
+      loofah (>= 2.0)
+      nokogiri (~> 1.6)
     io-like (0.3.0)
     jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
@@ -467,6 +471,7 @@ DEPENDENCIES
   github_api (= 0.13.1)
   heroku_rails_deflate (= 1.0.3)
   imagesLoaded_rails (= 4.1.0)
+  inline_svg (= 0.7.0)
   jbuilder (= 2.4.1)
   jquery-rails (= 4.1.1)
   jquery-turbolinks

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -14,7 +14,7 @@ class ProjectsController < ApplicationController
   # We *can* cache the badge result, and that's what matters anyway.
   before_action :set_cache_control_headers, only: [:badge]
 
-  helper_method :repo_data
+  helper_method :repo_data, :badge_file
 
   # GET /projects
   # GET /projects.json

--- a/app/views/projects/_table.html.erb
+++ b/app/views/projects/_table.html.erb
@@ -34,7 +34,7 @@
         <td><%= project.license %></td>
         <td><%= link_to project.user_name, project.user %></td>
         <td><%= project.badge_percentage %>%</td>
-        <td><%= link_to "<img src='/projects/#{project.id}/badge'>".html_safe,
+        <td><%= link_to inline_svg(badge_file(project.badge_status)),
                         project %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
I noticed in the server log that loading `/projects` would take one database query to get the table contents but then 30 more queries, one for the badge_status of each project as it's SVG image was loaded in a separate HTTP request.

So, this instead inlines the SVG's when displayed on the `/projects` page, though the rendering for badges to embed in Github is unaffected.