### PR TITLE
Clickable URLs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,14 +1,2 @@
 module ApplicationHelper
-  MARKDOWN_RENDERER = Redcarpet::Render::HTML.new(
-    filter_html: true, no_images: true,
-    no_styles: true, safe_links_only: true)
-  MARKDOWN_PROCESSOR = Redcarpet::Markdown.new(
-    ApplicationHelper::MARKDOWN_RENDERER,
-    no_intra_emphasis: true, autolink: true,
-    space_after_headers: true, fenced_code_blocks: true)
-
-  def self.markdown(content)
-    return '' if content.nil?
-    ApplicationHelper::MARKDOWN_PROCESSOR.render(content).html_safe
-  end
 end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -1,4 +1,12 @@
 module ProjectsHelper
+  MARKDOWN_RENDERER = Redcarpet::Render::HTML.new(
+    filter_html: true, no_images: true,
+    no_styles: true, safe_links_only: true)
+  MARKDOWN_PROCESSOR = Redcarpet::Markdown.new(
+    MARKDOWN_RENDERER,
+    no_intra_emphasis: true, autolink: true,
+    space_after_headers: true, fenced_code_blocks: true)
+
   def github_select
     # List original then forked Github projects, with headers
     fork_repos, original_repos = fork_and_original
@@ -16,6 +24,11 @@ module ProjectsHelper
 
   def fork_header(fork_repos)
     fork_repos.blank? ? [] : [['=> Forked Github Repos', '', 'none']]
+  end
+
+  def markdown(content)
+    return '' if content.blank?
+    MARKDOWN_PROCESSOR.render(content).html_safe
   end
 
   # Use the status_chooser to render the given criterion.

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -27,7 +27,7 @@ module ProjectsHelper
   end
 
   def markdown(content)
-    return '' if content.blank?
+    return '' if content.nil?
     MARKDOWN_PROCESSOR.render(content).html_safe
   end
 

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -131,7 +131,7 @@ Note that other projects may use the same name.
       <span>What is a brief description of the project?</span>
       <% if (is_disabled) %>
         <div class="discussion-markdown">
-          <%= ApplicationHelper.markdown(project[:description]) %>
+          <%= markdown(project[:description]) %>
         </div>
       <% else %>
         <%= render(partial: "details", locals: {
@@ -145,13 +145,25 @@ This information is used when displaying badge information.
 
       <div class="hidable-text-entry">
       <span>What is the URL for the project (as a whole)?</span>
-      <%= f.text_field :homepage_url, hide_label: true, class: "form-control", placeholder:'Project Website URL', label: "Project URL", disabled: is_disabled %>
+      <% if (is_disabled) %>
+        <div class="discussion-markdown">
+          <%= markdown(project.homepage_url) %>
+        </div>
+      <% else %>
+        <%= f.text_field :homepage_url, hide_label: true, class: "form-control", placeholder:'Project Website URL', label: "Project URL", disabled: is_disabled %>
+      <% end %>
       </div>
 
       <div class="hidable-text-entry">
       <span>What is the URL for the version control repository
             (it may the same as the project URL)?</span>
-      <%= f.text_field :repo_url, class:"form-control", hide_label: true, placeholder:'Project Repo URL', disabled: repo_disabled %>
+      <% if (is_disabled) %>
+        <div class="discussion-markdown">
+          <%= markdown(project.repo_url) %>
+        </div>
+      <% else %>
+        <%= f.text_field :repo_url, class:"form-control", hide_label: true, placeholder:'Project Repo URL', disabled: repo_disabled %>
+      <% end %>
       </div>
 
 <!-- TODO: MUST have a project or repo URL, SUGGESTED to use HTTPS.
@@ -256,7 +268,7 @@ Please use <a href="https://spdx.org/licenses/">SPDX license expression format</
       Other general comments about the project:<br>
       <% if (is_disabled) %>
         <div class="discussion-markdown">
-          <%= ApplicationHelper.markdown(project[:general_comments]) %>
+          <%= markdown(project[:general_comments]) %>
         </div>
       <% else %>
         <%= f.text_area :general_comments, class:"form-control",  hide_label: true, placeholder:'Additional Comments (in markdown)', disabled: is_disabled %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,4 +1,4 @@
-<% badge_hostname= (ENV['PUBLIC_HOSTNAME'] || 'localhost') %>
+<% badge_hostname = (ENV['PUBLIC_HOSTNAME'] || 'localhost') %>
 <% content_for :nav_progress do %>
 <div class="progress">
   <div id="badge-progress" class="progress-bar progress-bar-success badge-progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
@@ -63,7 +63,7 @@ There is also a
 </div>
 </div>
 
-<% if (is_disabled) %>
+<% if is_disabled %>
 <%   if ! %w(failing in_progress).include? project.badge_level %>
 <div class="row">
 <div class="col-xs-1"></div>
@@ -129,7 +129,7 @@ Note that other projects may use the same name.
 
       <div class="hidable-text-entry">
       <span>What is a brief description of the project?</span>
-      <% if (is_disabled) %>
+      <% if is_disabled %>
         <div class="discussion-markdown">
           <%= markdown(project[:description]) %>
         </div>
@@ -145,9 +145,9 @@ This information is used when displaying badge information.
 
       <div class="hidable-text-entry">
       <span>What is the URL for the project (as a whole)?</span>
-      <% if (is_disabled) %>
+      <% if is_disabled %>
         <div class="discussion-markdown">
-          <%= markdown(project.homepage_url) %>
+           <%= link_to_if project.contains_url?(project.homepage_url), project.homepage_url %>
         </div>
       <% else %>
         <%= f.text_field :homepage_url, hide_label: true, class: "form-control", placeholder:'Project Website URL', label: "Project URL", disabled: is_disabled %>
@@ -157,9 +157,9 @@ This information is used when displaying badge information.
       <div class="hidable-text-entry">
       <span>What is the URL for the version control repository
             (it may the same as the project URL)?</span>
-      <% if (is_disabled) %>
+      <% if is_disabled || repo_disabled%>
         <div class="discussion-markdown">
-          <%= markdown(project.repo_url) %>
+           <%= link_to_if project.contains_url?(project.repo_url), project.repo_url %>
         </div>
       <% else %>
         <%= f.text_field :repo_url, class:"form-control", hide_label: true, placeholder:'Project Repo URL', disabled: repo_disabled %>
@@ -266,7 +266,7 @@ Please use <a href="https://spdx.org/licenses/">SPDX license expression format</
       <br>
 
       Other general comments about the project:<br>
-      <% if (is_disabled) %>
+      <% if is_disabled %>
         <div class="discussion-markdown">
           <%= markdown(project[:general_comments]) %>
         </div>

--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -75,7 +75,7 @@
          <% if (is_disabled) %>
            <% if project[justification_symbol] %>
              <div class="justification-markdown">
-               <%= ApplicationHelper.markdown(project[justification_symbol]) %>
+               <%= markdown(project[justification_symbol]) %>
              </div>
            <% end %>
            <% if project[status_symbol] == 'Met' &&

--- a/app/views/projects/_table.html.erb
+++ b/app/views/projects/_table.html.erb
@@ -18,7 +18,7 @@
         <td><%= link_to project.id, project %></td>
         <td><%= link_to (project.name.presence || "(Name Unknown)"),
                 project %></td>
-        <td><%= ApplicationHelper.markdown(
+        <td><%= markdown(
                   (project.description || '').
                   truncate(160, separator: ' ')) %></td>
 

--- a/test/helpers/projects_helper_test.rb
+++ b/test/helpers/projects_helper_test.rb
@@ -1,34 +1,33 @@
 require 'test_helper'
 
-class ApplicationHelperTest < ActionView::TestCase
-  def setup
-  end
+class ProjectsHelperTest < ActionView::TestCase
+  include ProjectsHelper
 
   test 'markdown - simple' do
-    assert_equal "<p>hi</p>\n", ApplicationHelper.markdown('hi')
+    assert_equal "<p>hi</p>\n", markdown('hi')
   end
 
   test 'markdown - emphasis' do
-    assert_equal "<p><em>hi</em></p>\n", ApplicationHelper.markdown('*hi*')
+    assert_equal "<p><em>hi</em></p>\n", markdown('*hi*')
   end
 
   test 'markdown - bare URL' do
     assert_equal(
       '<p><a href="http://www.dwheeler.com">' \
       "http://www.dwheeler.com</a></p>\n",
-      ApplicationHelper.markdown('http://www.dwheeler.com'))
+      markdown('http://www.dwheeler.com'))
   end
 
   test 'markdown - angles around URL' do
     assert_equal(
       '<p><a href="http://www.dwheeler.com">' \
       "http://www.dwheeler.com</a></p>\n",
-      ApplicationHelper.markdown('<http://www.dwheeler.com>'))
+      markdown('<http://www.dwheeler.com>'))
   end
 
   test 'markdown - no script HTML' do
     assert_equal(
       "<p>Hello</p>\n",
-      ApplicationHelper.markdown('<script src="hi"></script>Hello'))
+      markdown('<script src="hi"></script>Hello'))
   end
 end


### PR DESCRIPTION
@david-a-wheeler This fixes #332 and also cleans up the markdown helper to be a regular instance method of ProjectHelper rather than a class method of ApplicationHelper.