### PR TITLE
Make contains URL functions match between client and server

### DIFF
--- a/app/assets/javascripts/project-form.js
+++ b/app/assets/javascripts/project-form.js
@@ -28,11 +28,14 @@ function polyfillDatalist() {
   }
 }
 
+// Note: This regex needs to be logically the same as the one used in
+// the server-side badge calculation, or it may confuse some users.
+// See app/models/project.rb function "contains_url?".
 function containsURL(justification) {
   if (!justification) {
     return false;
   } else {
-    return !!justification.match(/https?:\/\/[^ ]{5,}/);
+    return !!justification.match(/https?:\/\/[^ ]{5/);
   }
 }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -91,15 +91,20 @@ class Project < ActiveRecord::Base
     to_percentage met, Criteria.active.length
   end
 
-  # Does this contain a URL *anywhere* in the text?
+  # Does this contain a URL *anywhere* in the (justification) text?
+  # Note: This regex needs to be logically the same as the one used in the
+  # client-side badge calculation, or it may confuse some users.
+  # See app/assets/javascripts/*.js function "containsURL".
+  #
   # Note that we do NOT need to validate these URLs, because the BadgeApp
   # 1. escapes these (as part of normal processing) against XSS attacks, and
-  # 2. it does not traverse these URLs in its automated processing.
+  # 2. does not traverse these URLs in its automated processing.
   # Thus, this rule is intentionally *not* strict at all.  Contrast this
   # with the intentionally strict validation of the project and repo URLs,
-  # which *are* traversed and thus need to be much more strict.
+  # which *are* traversed by BadgeApp and thus need to be much more strict.
+  #
   def contains_url?(text)
-    text =~ %r{https?://.{3}}
+    text =~ %r{https?://[^ ]{5}}
   end
 
   private

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -20,7 +20,25 @@ class ProjectTest < ActiveSupport::TestCase
   test '#contains_url?' do
     assert Project.new.send :contains_url?, 'https://www.example.org'
     assert Project.new.send :contains_url?, 'http://www.example.org'
+    assert Project.new.send :contains_url?,
+                            'See also <http://x.org>.'
+    assert Project.new.send :contains_url?,
+                            'See also <http://x.org>.'
     refute Project.new.send :contains_url?, 'mailto://mail@example.org'
     refute Project.new.send :contains_url?, 'abc'
+    refute Project.new.send :contains_url?,
+                            'See also http://x for more information.'
+    refute Project.new.send :contains_url?, 'www.google.com'
+  end
+
+  test 'Rigorous project and repo URL checker' do
+    regex = UrlValidator::URL_REGEX
+    my_url = 'https://github.com/linuxfoundation/cii-best-practices-badge'
+    assert my_url =~ regex
+    assert 'https://kernel.org' =~ regex
+    assert_not 'https://' =~ regex
+    assert_not 'www.google.com' =~ regex
+    assert_not 'See also http://x.org for more information.' =~ regex
+    assert_not 'See also <http://x.org>.' =~ regex
   end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -18,17 +18,14 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test '#contains_url?' do
-    assert Project.new.send :contains_url?, 'https://www.example.org'
-    assert Project.new.send :contains_url?, 'http://www.example.org'
-    assert Project.new.send :contains_url?,
-                            'See also <http://x.org>.'
-    assert Project.new.send :contains_url?,
-                            'See also <http://x.org>.'
-    refute Project.new.send :contains_url?, 'mailto://mail@example.org'
-    refute Project.new.send :contains_url?, 'abc'
-    refute Project.new.send :contains_url?,
-                            'See also http://x for more information.'
-    refute Project.new.send :contains_url?, 'www.google.com'
+    assert Project.new.contains_url? 'https://www.example.org'
+    assert Project.new.contains_url? 'http://www.example.org'
+    assert Project.new.contains_url? 'See also http://x.org.'
+    assert Project.new.contains_url? 'See also <http://x.org>.'
+    refute Project.new.contains_url? 'mailto://mail@example.org'
+    refute Project.new.contains_url? 'abc'
+    refute Project.new.contains_url? 'See also http://x for more information.'
+    refute Project.new.contains_url? 'www.google.com'
   end
 
   test 'Rigorous project and repo URL checker' do
@@ -36,9 +33,9 @@ class ProjectTest < ActiveSupport::TestCase
     my_url = 'https://github.com/linuxfoundation/cii-best-practices-badge'
     assert my_url =~ regex
     assert 'https://kernel.org' =~ regex
-    assert_not 'https://' =~ regex
-    assert_not 'www.google.com' =~ regex
-    assert_not 'See also http://x.org for more information.' =~ regex
-    assert_not 'See also <http://x.org>.' =~ regex
+    refute 'https://' =~ regex
+    refute 'www.google.com' =~ regex
+    refute 'See also http://x.org for more information.' =~ regex
+    refute 'See also <http://x.org>.' =~ regex
   end
 end


### PR DESCRIPTION
    The client and server need to agree on what's required to
    have a URL in a justification.  Otherwise the subtle difference
    could produce confusing results in rare cases.  Also, add tests for them.
    
