### PR TITLE
Allow admins to easily send email to users

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,7 +9,7 @@
       <%= gravatar_for user %>
       <%= link_to user.name, user %>
       <% if current_user.admin? %>
-        <% if user.email.present? %>
+        <% if user.email? %>
     |     <a href="mailto:<%= CGI::escape(user.email).html_safe %>">email
             <%= user.email %></a>
         <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -8,7 +8,7 @@
     <li>
       <%= gravatar_for user %>
       <%= link_to user.name, user %>
-      <% if current_user.admin? %>
+      <% if current_user&.admin? %>
         <% if user.email? %>
     |     <a href="mailto:<%= CGI::escape(user.email).html_safe %>">email
             <%= user.email %></a>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -8,6 +8,10 @@
       <%= gravatar_for user %>
       <%= link_to user.name, user %>
       <% if current_user.admin? %>
+        <% if user.email.present? %>
+          <%# This doesn't handle ? in email addresses, but those are rare. %>
+    |     <a href="mailto:<%= user.email %>">email</a>
+        <% end %>
     |   <%= link_to "delete", user, method: :delete,
                                     data: { confirm: "Are you sure?" } %>
       <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,4 @@
+<% require 'cgi' %>
 
 <div class="jumbotron">
 <h2 class>All users</h2>
@@ -9,8 +10,8 @@
       <%= link_to user.name, user %>
       <% if current_user.admin? %>
         <% if user.email.present? %>
-          <%# This doesn't handle ? in email addresses, but those are rare. %>
-    |     <a href="mailto:<%= user.email %>">email</a>
+    |     <a href="mailto:<%= CGI::escape(user.email).html_safe %>">email
+            <%= user.email %></a>
         <% end %>
     |   <%= link_to "delete", user, method: :delete,
                                     data: { confirm: "Are you sure?" } %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,8 +30,15 @@
    See <a href="https://github.com/<%= @user.nickname %>">this user's
    external page</a>.
   <% end %>
+  <% if current_user.admin? %>
+    As an admin, you may also:
+    <% if @user.email.present? %>
+      <%# This doesn't handle ? in email addresses, but those are rare. %>
+      <a href="mailto:<%= @user.email %>">email</a> |
+    <% end %>
+    <%= link_to "delete", @user, method: :delete,
+                                 data: { confirm: "Are you sure?" } %>
+  <% end %>
  </div>
-
 </div>
-
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <% if current_user.admin? %>
     As an admin, you may also:
-    <% if @user.email.present? %>
+    <% if @user.email? %>
       <a href="mailto:<%= CGI::escape(@user.email).html_safe %>">email
         <%= @user.email %></a> |
     <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,7 +31,7 @@
    See <a href="https://github.com/<%= @user.nickname %>">this user's
    external page</a>.
   <% end %>
-  <% if current_user.admin? %>
+  <% if current_user&.admin? %>
     As an admin, you may also:
     <% if @user.email? %>
       <a href="mailto:<%= CGI::escape(@user.email).html_safe %>">email

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,4 @@
+<% require 'cgi' %>
 <div class="center">
 
  <% provide(:title, @user.name) %>
@@ -33,8 +34,8 @@
   <% if current_user.admin? %>
     As an admin, you may also:
     <% if @user.email.present? %>
-      <%# This doesn't handle ? in email addresses, but those are rare. %>
-      <a href="mailto:<%= @user.email %>">email</a> |
+      <a href="mailto:<%= CGI::escape(@user.email).html_safe %>">email
+        <%= @user.email %></a> |
     <% end %>
     <%= link_to "delete", @user, method: :delete,
                                  data: { confirm: "Are you sure?" } %>

--- a/test/integration/admin_users_show_test.rb
+++ b/test/integration/admin_users_show_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class AdminUsersShowTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:test_user)
+    @admin_user = users(:admin_user)
+    @melissa = users(:test_user_melissa)
+  end
+
+  test 'non-logged-in show user' do
+    get user_path(@melissa)
+    assert_response :success
+    assert_select 'a[href=?]'.dup, 'mailto:melissa%40example.com', false
+  end
+
+  test 'non-admin show user' do
+    log_in_as(@user)
+    get user_path(@melissa)
+    assert_response :success
+    assert_select 'a[href=?]'.dup, 'mailto:melissa%40example.com', false
+  end
+
+  test 'admin show user' do
+    log_in_as(@admin_user)
+    get user_path(@melissa)
+    assert_response :success
+    assert_select 'a[href=?]'.dup, 'mailto:melissa%40example.com'
+  end
+end


### PR DESCRIPTION
This will make it easier for admins to provide focused feedback
to specific users.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>