### PR TITLE
Update rake task

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,5 +31,6 @@ deployment:
 general:
   artifacts:
     - 'coverage'
+    - 'license_finder_report.html'
     - 'log/test.log'
     - 'tmp/capybara'

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -172,9 +172,7 @@ task :bundle_viz do
 end
 
 desc 'Deploy current origin/master to staging'
-task :deploy_staging do
-  Rake::Task['production_to_staging'].reenable
-  Rake::Task['production_to_staging'].invoke
+task deploy_staging: :production_to_staging do
   sh 'git checkout staging && git pull && ' \
      'git merge --ff-only origin/master && git push && git checkout master'
 end

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -173,6 +173,8 @@ end
 
 desc 'Deploy current origin/master to staging'
 task :deploy_staging do
+  Rake::Task['production_to_staging'].reenable
+  Rake::Task['production_to_staging'].invoke
   sh 'git checkout staging && git pull && ' \
      'git merge --ff-only origin/master && git push && git checkout master'
 end


### PR DESCRIPTION
Signed-off-by: Dan Kohn <dan@dankohn.com>

@david-a-wheeler As discussed, this adds pulling the production database to staging when we deploy master to staging. Also, I make the license finder report available in the Artifacts tab on CircleCI.