### PR TITLE
Fix bug in displaying project statistics

### DIFF
--- a/app/models/project_stat.rb
+++ b/app/models/project_stat.rb
@@ -3,22 +3,26 @@
 class ProjectStat < ActiveRecord::Base
   STAT_VALUES = %w(0 25 50 75 90 100).freeze
 
-  after_initialize :stamp
-
+  # Stamp (fill in) the current values into a ProjectStat. Uses database.
   # rubocop:disable Metrics/AbcSize
   def stamp
-    # Count projects at different levels of completion
+    # Use a transaction to get values from a single consistent point in time.
     Project.transaction do
       # binding.pry
+      # Count projects at different levels of completion
       STAT_VALUES.each do |completion|
         send "percent_ge_#{completion}=", Project.gteq(completion).count
       end
+      # These use 1.day.ago, so a create or updates in 24 hours + fractional
+      # seconds won't be counted today, and *might* not be counted previously.
+      # This isn't important enough to solve.
       self.created_since_yesterday = Project.created_since(1.day.ago).count
 
       # Exclude newly-created records from updated_since count
       self.updated_since_yesterday = Project.updated_since(1.day.ago).count -
-                                     Project.created_since(1.day.ago).count
+                                     created_since_yesterday
     end
+    self # Return self to support method chaining
   end
   # rubocop:enable Metrics/AbcSize
 end

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -294,5 +294,5 @@ Rake::Task['test:run'].enhance ['test:features']
 # Configure your system (e.g., Heroku) to run this daily.  If you're using
 # Heroku, see: https://devcenter.heroku.com/articles/scheduler
 task daily: :environment do
-  ProjectStat.create!
+  ProjectStat.new.stamp.save!
 end

--- a/test/models/project_stat_test.rb
+++ b/test/models/project_stat_test.rb
@@ -6,7 +6,8 @@ class ProjectStatTest < ActiveSupport::TestCase
   def setup
     # Normalize time in order to test timestamps
     travel_to Time.zone.parse('2015-03-01T12:00:00') do
-      @project_stat = ProjectStat.create!
+      @project_stat = ProjectStat.new.stamp
+      @project_stat.save!
     end
   end
 


### PR DESCRIPTION
Fix display bug.  ProjectStat was automatically setting values
on initialization, but that meant that any attempt to display past values
would recalculate and display current values.

While we're changing it, eliminate one unnecessary SQL query when
calculating the project statistic values.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>