### PR TITLE
In /projects list add 'alt' tag to img for accessibility

### DIFF
--- a/app/views/projects/_table.html.erb
+++ b/app/views/projects/_table.html.erb
@@ -34,7 +34,7 @@
         <td><%= project.license %></td>
         <td><%= link_to project.user_name, project.user %></td>
         <td><%= project.badge_percentage %>%</td>
-        <td><%= link_to "<img src='/projects/#{project.id}/badge'>".html_safe,
+        <td><%= link_to "<img src='/projects/#{project.id}/badge' alt='Badge level for project #{project.id} is #{project.badge_percentage}%'>".html_safe,
                         project %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
The W3C validator noted that these img references did not have
an 'alt' value for accessibility.  Fix that.
This partly addresses issue #390.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>