### PR TITLE
Automatically confirm overwriting staging with production

### DIFF
--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -253,7 +253,8 @@ end
 desc 'Copy production database to staging, overwriting staging database'
 task :production_to_staging do
   sh 'heroku pg:backups restore $(heroku pg:backups public-url ' \
-     '--app production-bestpractices) DATABASE_URL --app staging-bestpractices'
+     '--app production-bestpractices) DATABASE_URL ' \
+     '--app staging-bestpractices --confirm staging-bestpractices'
   sh 'heroku run bundle exec rake db:migrate --app staging-bestpractices'
 end
 


### PR DESCRIPTION
There's no need to confirm when we're overwriting the staging database
with production; we *want* staging to be as similar as possible
to production.  This commit automatically confirms the overwrite.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>