### PR TITLE
All repo and project URLs with UTF-8 encoding. Fixes #402

### DIFF
--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
+require 'uri'
+
 class UrlValidator < ActiveModel::EachValidator
+  # Check URL (invoked in models where "validates ... url: true").
+  # These are the rules checked by the *server*.  The client does some
+  # quick sanity checks (see app/projects/new.html.erb), which should not
+  # forbid anything we'd allow, but we can't trust
+  # those checks because an attacker can easily bypass client-side checks.
   # The URL validation rules are somewhat overly strict, but should serve;
   # the idea is to prevent attackers from inserting redirecting URLs
   # that can sometimes be used to attack third-party sites via the BadgeApp.
-  # For example, this does *not* include "?...", "%..", or ones with <).
+  # For example, this does *not* include "?...", or ones with <, and the
+  # use of %-encoded bytes is restricted.
   # We can gradually loosen this if needed.  Note that this pattern is
   # more restrictive than the ones we allow in markdown justifications,
   # because the BadgeApp doies *not* follow those URLs for further processing.
@@ -11,13 +19,26 @@ class UrlValidator < ActiveModel::EachValidator
   # that by *spec* are legal.  The first part is an expression of the DNS spec,
   # the latter simply limits the character set used in the path.
   URL_REGEX =
-    %r{\A(|https?://[A-Za-z0-9][-A-Za-z0-9_.]*(/[-A-Za-z0-9_.:/+!,#]*)?)\z}
+    %r{\A(|  # Empty allowed
+        https?://
+        [A-Za-z0-9][-A-Za-z0-9_.]*  # domain name per DNS spec; includes I18N.
+        (/
+          ([-A-Za-z0-9_.:/+!,#]|    # allow these ASCII chars.
+           %(20|[89A-Ea-e][0-9A-Fa-f]|[Ff][0-7]))*  # Allow some %-encoded
+        )?)\z}x
+  URL_MESSAGE = 'must begin with http: or https: and use a limited charset'
 
-  URL_MESSAGE = 'must begin with http: or https: and use a limited' \
-                ' charset'
+  # Return true if URL matches URL_REGEX and its decoding is valid UTF-8.
+  def url_acceptable?(value)
+    if !(value =~ URL_REGEX)
+      false
+    else
+      URI.unescape(value).force_encoding('UTF-8').valid_encoding?
+    end
+  end
 
   def validate_each(record, attribute, value)
-    return if value =~ URL_REGEX
+    return if url_acceptable?(value)
     record.errors.add attribute, (options[:message] || URL_MESSAGE)
   end
 end

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,6 +1,17 @@
 
 <% post_delay_warning = 'There may be a significant delay after submitting ' \
-     'as we try to automatically fill in information.' %>
+     'as we try to automatically fill in information.'
+   # Quick check of project and repo URLs.  This check is for responsiveness,
+   # not for security; they're checked more rigorously
+   # at the server (see app/validators/url_validator.rb).
+   # This pattern is intentionally limited, e.g., we don't allow '?', to make
+   # it harder to use this app to attack improperly-written sites.
+   # The regex syntax here is per the *HTML* spec for HTML5 patterns, so
+   # "^" and "$" are not needed.
+   domain_pattern = '[A-Za-z0-9_][-A-Za-z0-9_.]*'
+   url_pattern = 'https?:\/\/' + domain_pattern + \
+     '(\/([-A-Za-z0-9_.:\/\+!,#]|%(20|[89A-Ea-e][0-9A-Fa-f]|[Ff][0-7]))*)?'
+%>
 <% if logged_in? %>
   <div class='row'>
   <div class="col-md-12">
@@ -29,14 +40,13 @@
       <!-- Note: Server tests URLs, this is just sanity checking -->
       <%= f.text_field :homepage_url, class:"form-control",
             type: 'url', hide_label: true,
-            pattern: '^(|https?:\/\/[A-Za-z0-9_][-A-Za-z0-9_.]*(\/[-A-Za-z0-9_.:\/\+!,#]*)?)',
-
+            pattern: url_pattern,
             placeholder:'http(s)://... for project home page URL' %>
       <span>What is the URL for the version control repository
             (it may the same as the project home page)? Start with http(s):// (many characters are not allowed, including "?")</span>
       <%= f.text_field :repo_url, class:"form-control",
             type: 'url', hide_label: true,
-            pattern: '^(|https?:\/\/[A-Za-z0-9_][-A-Za-z0-9_.]*(\/[-A-Za-z0-9_.:\/\+!,#]*)?)',
+            pattern: url_pattern,
             placeholder:'http(s)://... for project repo URL' %>
      <%= f.submit 'Submit URL', class: 'btn btn-primary',
                   'data-toggle' => 'tooltip', title: post_delay_warning %>

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -34,10 +34,53 @@ class ProjectTest < ActiveSupport::TestCase
     regex = UrlValidator::URL_REGEX
     my_url = 'https://github.com/linuxfoundation/cii-best-practices-badge'
     assert my_url =~ regex
+
+    # Here we just the regex directly, to make sure it's okay.
     assert 'https://kernel.org' =~ regex
     refute 'https://' =~ regex
     refute 'www.google.com' =~ regex
     refute 'See also http://x.org for more information.' =~ regex
     refute 'See also <http://x.org>.' =~ regex
+
+    # Here we use the full validator.  We stub out the info necessary
+    # to create a validator instance to test (we won't really use them).
+    validator = UrlValidator.new(attributes: %i(:repo_url :project_url))
+    assert validator.url_acceptable?(my_url)
+    assert validator.url_acceptable?('https://kernel.org')
+    assert validator.url_acceptable?('') # Empty allowed.
+    refute validator.url_acceptable?('https://')
+    refute validator.url_acceptable?('www.google.com')
+    refute validator.url_acceptable?('See also http://x.org for more.')
+    refute validator.url_acceptable?('See also <http://x.org>.')
+    assert validator.url_acceptable?('http://google.com')
+    # We don't allow '?'
+    refute validator.url_acceptable?('http://google.com?hello')
+    # We do allow fragments, e.g., #
+    refute validator.url_acceptable?('http://google.com#hello')
+
+    # Accept U+0020 (space) and U+00E9 c3 a9 "LATIN SMALL LETTER E WITH ACUTE"
+    assert validator.url_acceptable?('https://github.com/linuxfoundation/' \
+                                    'cii-best-practices-badge%20%c3%a9')
+    # Accept U+8C0A Unicode Han Character 'friendship; appropriate, suitable'
+    # encoded in UTF-8 as 0xE8 0xB0 0x8A (e8b08a); see
+    # http://www.fileformat.info/info/unicode/char/8c0a/index.htm
+    assert validator.url_acceptable?('https://github.com/linuxfoundation/' \
+                                    '%E8%B0%8A')
+    # Accept U+1000 Unicode Character 'MYANMAR LETTER KA'
+    # encoded in UTF-8 as 0xE1 0x80 0x80
+    # http://www.fileformat.info/info/unicode/char/1000/index.htm
+    assert validator.url_acceptable?('https://github.com/linuxfoundation/' \
+                                    '%e1%80%80')
+    # Don't accept "c0 80", an overlong (2-byte) encoding of U+0000 (NUL).
+    # Note that "modified UTF-8" does accept this.
+    refute validator.url_acceptable?('https://github.com/linuxfoundation/' \
+                                    'cii-best-practices-badge%20%c0%80')
+    # Don't accept non-UTF-8, even if the individual bytes are acceptable.
+    refute validator.url_acceptable?('https://github.com/linuxfoundation/' \
+                                    'cii-best-practices-badge%eex')
+    refute validator.url_acceptable?('https://github.com/linuxfoundation/' \
+                                    'cii-best-practices-badge%ee')
+    refute validator.url_acceptable?('https://github.com/linuxfoundation/' \
+                                    'cii-best-practices-badge%ff%ff')
   end
 end


### PR DESCRIPTION
Modify the handling of repo and project URLs to allow
embedded UTF-8 encoding, but with careful limitations to protect security.
In particular, we are limiting URLs so the BadgeApp has less utility for
attacking other sites (e.g., we don't allow "?"), but this allows
%-encoding of a number of characters.  This change allows %20 as the
encoding for space.  It requires that URLs, once decoded, be valid UTF-8.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>