### PR TITLE
Modify footer layout to clarify what to do for help

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,7 +2,10 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12 col-sm-12 col-md-7">
-        <small>© 2015-2016 Core Infrastructure Initiative, a Linux Foundation Collaborative Project. All Rights Reserved.</small>
+        <small>© 2015-2016 Core Infrastructure Initiative, a Linux Foundation Collaborative Project. All Rights Reserved.
+If you have a problem with the site, please
+<a href="https://github.com/linuxfoundation/cii-best-practices-badge/issues">file an issue</a>.
+</small>
       </div>
     <div class="col-xs-12 col-sm-12 col-md-5">
       <nav>


### PR DESCRIPTION
Add to the footer a link to the issue tracker.
That way, if users have problems anywhere on the site,
there's information on the page explaning what to do next.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>