### PR TITLE
install updates

### DIFF
--- a/install-badge-dev-env
+++ b/install-badge-dev-env
@@ -3,7 +3,11 @@ echo 'install-badge-dev-env: Auto-install development environment for BadgeApp.'
 echo 'See INSTALL.md for more information.'
 
 # Set configure options defaults; set their values with environment variables.
-: "${MYINSTALL_SYSTEM_INSTALL_PREFIX:=sudo}"
+if [ "$(uname)" != 'Darwin' ] ; then  # NOT MacOS
+  : "${MYINSTALL_SYSTEM_INSTALL_PREFIX:=sudo}"
+else
+  : "${MYINSTALL_SYSTEM_INSTALL_PREFIX:= }"
+fi
 : "${MYINSTALL_SYSTEM_INSTALL_PACKAGES:=yes}"
 : "${MYINSTALL_RBENV:=yes}" # Should we install and use rbenv?
 : "${MYINSTALL_RBENV_BUNDLER:=yes}" # Should we install and use rbenv-bundler?
@@ -138,8 +142,6 @@ is_command git || add_pkg git
 # bootstrap the installation and building of that version.
 is_command ruby || add_pkg ruby
 
-# SQLite3 database system, used in development for data storage
-add_pkg sqlite3
 
 # We will build ruby via rbenv and ruby-build. This requires either those
 # packages themselves, or a number of other packages to build them.
@@ -149,7 +151,7 @@ case "$manager" in
   brew)
     # We'll use the brew version. Install these to rebuild rbenv:
     # add_pkg openssl libyaml libffi
-    add_pkg phantomjs198 rbenv ruby-build ;;
+    add_pkg phantomjs rbenv ruby-build ;;
   apt-get)
     # We'll use the system version.  If you want to use the latest one
     # on GitHub, instead install these system components first:


### PR DESCRIPTION
Signed-off-by: Dan Kohn <dan@dankohn.com>

These changes were necessary but not sufficient. Only the first line of `add-pkg` libraries are getting included, so no cmake or postgres. See the following log of an install on my new Mac:

```
$ ./install-badge-dev-env 
install-badge-dev-env: Auto-install development environment for BadgeApp.
See INSTALL.md for more information.

STAGE 1: Determine the package manager to use.
Will use the installer command 'brew install'

STAGE 2: Identifying and install system packages
About to install system packages with the command:
    brew install  phantomjs rbenv ruby-build
==> Installing dependencies for phantomjs: openssl
==> Installing phantomjs dependency: openssl
==> Downloading https://homebrew.bintray.com/bottles/openssl-1.0.2h_1.el_capitan.bottle.tar.gz
######################################################################## 100.0%
==> Pouring openssl-1.0.2h_1.el_capitan.bottle.tar.gz
==> Caveats
A CA file has been bootstrapped using certificates from the system
keychain. To add additional certificates, place .pem files in
  /usr/local/etc/openssl/certs

and run
  /usr/local/opt/openssl/bin/c_rehash

This formula is keg-only, which means it was not symlinked into /usr/local.

Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries

Generally there are no consequences of this for you. If you build your
own software and it requires this formula, you'll need to add to your
build variables:

    LDFLAGS:  -L/usr/local/opt/openssl/lib
    CPPFLAGS: -I/usr/local/opt/openssl/include

==> Summary
🍺  /usr/local/Cellar/openssl/1.0.2h_1: 1,691 files, 12M
==> Installing phantomjs
==> Downloading https://homebrew.bintray.com/bottles/phantomjs-2.1.1.el_capitan.bottle.tar.gz
######################################################################## 100.0%
==> Pouring phantomjs-2.1.1.el_capitan.bottle.tar.gz
🍺  /usr/local/Cellar/phantomjs/2.1.1: 49 files, 50.5M
==> Installing dependencies for rbenv: autoconf, pkg-config, ruby-build
==> Installing rbenv dependency: autoconf
==> Downloading https://homebrew.bintray.com/bottles/autoconf-2.69.el_capitan.bottle.4.tar.gz
######################################################################## 100.0%
==> Pouring autoconf-2.69.el_capitan.bottle.4.tar.gz
==> Caveats
Emacs Lisp files have been installed to:
  /usr/local/share/emacs/site-lisp/autoconf
==> Summary
🍺  /usr/local/Cellar/autoconf/2.69: 70 files, 3.0M
==> Installing rbenv dependency: pkg-config
==> Downloading https://homebrew.bintray.com/bottles/pkg-config-0.29.1.el_capitan.bottle.tar.gz
######################################################################## 100.0%
==> Pouring pkg-config-0.29.1.el_capitan.bottle.tar.gz
🍺  /usr/local/Cellar/pkg-config/0.29.1: 10 files, 627.2K
==> Installing rbenv dependency: ruby-build
==> Downloading https://github.com/rbenv/ruby-build/archive/v20160426.tar.gz
==> Downloading from https://codeload.github.com/rbenv/ruby-build/tar.gz/v20160426
######################################################################## 100.0%
==> ./install.sh
🍺  /usr/local/Cellar/ruby-build/20160426: 215 files, 124.6K, built in 1 second
==> Installing rbenv
==> Downloading https://homebrew.bintray.com/bottles/rbenv-1.0.0.el_capitan.bottle.tar.gz
######################################################################## 100.0%
==> Pouring rbenv-1.0.0.el_capitan.bottle.tar.gz
==> Caveats
Rbenv stores data under ~/.rbenv by default. If you absolutely need to
store everything under Homebrew's prefix, include this in your profile:
  export RBENV_ROOT=/usr/local/var/rbenv

To enable shims and autocompletion, run this and follow the instructions:
  rbenv init
==> Summary
🍺  /usr/local/Cellar/rbenv/1.0.0: 36 files, 61.9K

STAGE 3: Install and setup rbenv and ruby-build
rbenv already installed.
Downloading and installing rbenv-bundler from GitHub
Cloning into '/Users/dan/.rbenv/plugins/bundler'...
remote: Counting objects: 547, done.
remote: Total 547 (delta 0), reused 0 (delta 0), pack-reused 547
Receiving objects: 100% (547/547), 99.25 KiB | 0 bytes/s, done.
Resolving deltas: 100% (200/200), done.
Checking connectivity... done.

STAGE 4: For this project, force install fixed version of ruby
Using rbenv to locally install ruby version 2.3.1
Downloading ruby-2.3.1.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2
Installing ruby-2.3.1...
Installed ruby-2.3.1 to /Users/dan/.rbenv/versions/2.3.1


STAGE 5: Install gems (including bundler and Rails)
https://rubygems.org added to sources
Fetching: bundler-1.12.5.gem (100%)
Successfully installed bundler-1.12.5
Parsing documentation for bundler-1.12.5
Installing ri documentation for bundler-1.12.5
Done installing documentation for bundler after 10 seconds
1 gem installed
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Fetching dependency metadata from https://rubygems.org/
Installing rake 11.1.2
Installing i18n 0.7.0
Using json 1.8.3
Installing minitest 5.9.0
Installing thread_safe 0.3.5
Installing builder 3.2.2
Installing erubis 2.7.0
Installing mini_portile2 2.0.0
Installing rack 1.6.4
Installing mime-types 2.99.2
Installing arel 6.0.3
Installing addressable 2.4.0
Installing io-like 0.3.0
Installing ast 2.2.0
Installing execjs 2.7.0
Using bundler 1.12.5
Installing thor 0.19.1
Installing concurrent-ruby 1.0.2
Installing awesome_print 1.6.1
Installing bcrypt 3.1.11 with native extensions
Installing sass 3.4.22
Installing will_paginate 3.1.0
Installing bootstrap_form 2.3.0
Installing brakeman 3.3.0
Installing uniform_notifier 1.10.0
Installing byebug 9.0.5 with native extensions
Installing ffi 1.9.10 with native extensions
Installing cliver 0.3.2
Installing sexp_processor 4.7.0
Installing docile 1.1.5
Installing simplecov-html 0.10.0
Installing url 0.3.2
Installing coderay 1.1.1
Installing coffee-script-source 1.10.0
Installing colorize 0.7.7
Installing safe_yaml 1.0.4
Installing debug_inspector 0.0.2 with native extensions
Installing dotenv 2.1.1
Installing multi_json 1.12.1
Installing multipart-post 2.0.0
Installing fastly 1.4.3
Installing hashie 3.4.4
Installing jwt 1.5.1
Installing multi_xml 0.5.5
Installing terminal-table 1.5.2
Installing hashdiff 0.3.0
Installing kramdown 1.11.1
Installing rubyzip 1.2.0
Installing xml-simple 1.1.5
Installing method_source 0.8.2
Installing mixlib-cli 1.6.0
Installing mixlib-config 2.2.1
Installing newrelic_rpm 3.15.2.317
Installing request_store 1.3.1
Installing pg 0.18.4 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/dan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/pg-0.18.4/ext
/Users/dan/.rbenv/versions/2.3.1/bin/ruby -r ./siteconf20160601-26363-o1gf0v.rb extconf.rb
checking for pg_config... no
No pg_config... trying anyway. If building fails, please try again with
 --with-pg-config=/path/to/pg_config
checking for libpq-fe.h... no
Can't find the 'libpq-fe.h header
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/Users/dan/.rbenv/versions/2.3.1/bin/$(RUBY_BASE_NAME)
	--with-pg
	--without-pg
	--enable-windows-cross
	--disable-windows-cross
	--with-pg-config
	--without-pg-config
	--with-pg_config
	--without-pg_config
	--with-pg-dir
	--without-pg-dir
	--with-pg-include
	--without-pg-include=${pg-dir}/include
	--with-pg-lib
	--without-pg-lib=${pg-dir}/lib

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /Users/dan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/extensions/x86_64-darwin-15/2.3.0-static/pg-0.18.4/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /Users/dan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/pg-0.18.4 for inspection.
Results logged to /Users/dan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/extensions/x86_64-darwin-15/2.3.0-static/pg-0.18.4/gem_make.out
Installing websocket-extensions 0.1.2
Installing powerpack 0.1.1
Installing rugged 0.24.0 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/dan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rugged-0.24.0/ext/rugged
/Users/dan/.rbenv/versions/2.3.1/bin/ruby -r ./siteconf20160601-26363-11o6uzb.rb extconf.rb
checking for gmake... no
checking for make... yes
checking for cmake... no
ERROR: CMake is required to build Rugged.
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/Users/dan/.rbenv/versions/2.3.1/bin/$(RUBY_BASE_NAME)
	--use-system-libraries

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /Users/dan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/extensions/x86_64-darwin-15/2.3.0-static/rugged-0.24.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /Users/dan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rugged-0.24.0 for inspection.
Results logged to /Users/dan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/extensions/x86_64-darwin-15/2.3.0-static/rugged-0.24.0/gem_make.out
Installing require_all 1.3.3
Installing ruby-progressbar 1.8.1
Installing rainbow 2.1.0
Installing unicode-display_width 1.0.5
Installing slop 3.6.0
Installing puma 3.4.0 with native extensions
Installing rack-timeout 0.4.2
Installing rails_serve_static_assets 0.0.5
Installing rails_stdout_logging 0.0.5
Installing tilt 2.0.4
Installing redcarpet 3.3.4 with native extensions
Installing ruby-graphviz 1.2.2
Installing useragent 0.16.7
Installing websocket 1.2.3
Installing spring 1.7.1
Installing vcr 3.0.3
Installing yaml-lint 0.0.7
Installing faker 1.6.3
Installing minitest-metadata 0.6.0
Installing minitest-retry 0.1.4
Installing tzinfo 1.2.2
Installing descendants_tracker 0.0.4
Installing nokogiri 1.6.7.2 with native extensions
Installing rack-test 0.6.3
Installing mail 2.6.4
Installing launchy 2.4.3
Installing archive-zip 0.7.0
Installing parser 2.3.1.0
Installing autoprefixer-rails 6.3.6.1
Installing uglifier 3.0.0
Installing bundler-audit 0.5.0
Installing sprockets 3.6.0
Installing bootstrap-will_paginate 0.0.10
Installing childprocess 0.5.9
Installing code_analyzer 0.4.5
Installing ruby_parser 3.8.2
Installing simplecov 0.11.2
Installing coffee-script 2.4.1
Installing crack 0.4.3
Installing eslintrb 2.0.4
Installing faraday 0.9.2
Installing omniauth 1.3.1
Installing httparty 0.13.7
Installing m 1.5.0
Installing mdl 0.3.1
An error occurred while installing pg (0.18.4), and Bundler cannot continue.
Make sure that `gem install pg -v '0.18.4'` succeeds before bundling.
Dans-MacBook:~/Dropbox/Documents/dev/cii-best-practices-badge (dan-install-updates)$
```