### PR TITLE
Add rel=nofollow for repo and project URLs. Fixes #422

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -128,7 +128,7 @@ This information is used when displaying badge information.
       <span>What is the URL for the project (as a whole)?</span>
       <% if is_disabled %>
         <div class="discussion-markdown">
-           <%= link_to_if project.contains_url?(project.homepage_url), project.homepage_url, project.homepage_url %>
+           <%= link_to_if project.contains_url?(project.homepage_url), project.homepage_url, project.homepage_url, rel: 'nofollow' %>
         </div>
       <% else %>
         <%= f.text_field :homepage_url, hide_label: true, class: "form-control", placeholder:'Project Website URL', label: "Project URL", disabled: is_disabled %>
@@ -140,7 +140,7 @@ This information is used when displaying badge information.
             (it may the same as the project URL)?</span>
       <% if is_disabled || repo_disabled%>
         <div class="discussion-markdown">
-           <%= link_to_if project.contains_url?(project.repo_url), project.repo_url, project.repo_url %>
+           <%= link_to_if project.contains_url?(project.repo_url), project.repo_url, project.repo_url, rel: 'nofollow' %>
         </div>
       <% else %>
         <%= f.text_field :repo_url, class:"form-control", hide_label: true, placeholder:'Project Repo URL', disabled: repo_disabled %>

--- a/app/views/projects/_table.html.erb
+++ b/app/views/projects/_table.html.erb
@@ -26,7 +26,7 @@
           <%# Defend against bad data - link only if plausible URL. %>
           <% if project.homepage_url.presence &&
                 project.homepage_url.match(/\Ahttps?:\/\//) %>
-            <a href="<%= project.homepage_url %>"><%= project.homepage_url %></a>
+            <a rel='nofollow' href="<%= project.homepage_url %>"><%= project.homepage_url %></a>
           <% else %>
             <%= project.homepage_url %>
           <% end %>


### PR DESCRIPTION
This will slightly discourage people from trying to create
nonsense badge entries to increase their search engine rankings,
by marking repo and project URLs as 'nofollow'.
For more information on nofollow, see:
https://en.wikipedia.org/wiki/Nofollow
By itself this commit doesn't do anything with generated markdown;
so far that hasn't been a problem.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>