### PR TITLE
This fixes extra spacing at the top of the page on small screens

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -35,7 +35,7 @@ body {
 }
 @media (max-width: 767px) {
   body {
-    padding-top: 240px;
+    padding-top: 100px;
   }
 }
 


### PR DESCRIPTION
This change will fix extra space at the top of the page caused by the previous header fix.