### PR TITLE
Redirect activated user to login if they try to sign up. Fixes issue #515

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,9 +24,8 @@ class UsersController < ApplicationController
   # rubocop: disable Metrics/MethodLength
   def create
     @user = User.find_by(email: user_params[:email].downcase)
-    if @user && !@user.activated
-      regenerate_activation_digest
-      send_activation
+    if @user
+      redirect_existing
     else
       @user = User.new(user_params)
       @user.provider = 'local'
@@ -58,6 +57,17 @@ class UsersController < ApplicationController
     User.find(params[:id]).destroy
     flash[:success] = 'User deleted'
     redirect_to users_url
+  end
+
+  def redirect_existing
+    if @user.activated
+      flash[:info] = 'That user already exists. ' \
+                     'Did you mean to sign in?'
+      redirect_to login_url
+    else
+      regenerate_activation_digest
+      send_activation
+    end
   end
 
   def send_activation

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -59,7 +59,7 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
       }
     end
     assert_equal 1, ActionMailer::Base.deliveries.size
-    assert_difference 'User.count', 0 do
+    assert_no_difference 'User.count' do
       post users_path, user: {
         name:  'Example User',
         email: 'user@example.com',
@@ -76,5 +76,21 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_template 'users/show'
     assert user_logged_in?
+  end
+
+  test 'redirect activated user to login' do
+    @user = users(:test_user)
+    assert_no_difference 'User.count' do
+      post users_path, user: {
+        name:  @user.name,
+        email: @user.email,
+        password:              'password',
+        password_confirmation: 'password'
+      }
+    end
+    assert_not flash.empty?
+    follow_redirect!
+    assert_template 'sessions/new'
+    assert_not user_logged_in?
   end
 end


### PR DESCRIPTION
This fixes issue #515. I created a new method redirect_existing because I was getting an Metrics/ABCsize offense for create if I had the conditional statements in the new method contained within create.

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>
