### PR TITLE
Add a web UI for sorting projects, fixes #459

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -52,4 +52,21 @@ module ProjectsHelper
   def repo_url_disabled?(project)
     true unless current_user.admin? || !project.repo_url?
   end
+
+  # Return HTML for a sortable header.
+  def sortable_header(title, field_name)
+    new_params = params.merge(sort: field_name)
+    if params[:sort] == field_name && params[:sort_direction] != 'desc'
+      new_params[:sort_direction] = 'desc'
+    else
+      new_params.delete(:sort_direction)
+    end
+    # The html_safe assertion here allows the HTML of
+    # <a href...> to go through.  This *is* handled for security;
+    # params.merge performs the URL encoding as required, and "title" is
+    # trusted (it's provided by the code, not by a potential attacker).
+    # rubocop:disable Rails/OutputSafety
+    "<a href=\"#{url_for(new_params)}\">#{title}</a>".html_safe
+    # rubocop:enable Rails/OutputSafety
+  end
 end

--- a/app/views/projects/_table.html.erb
+++ b/app/views/projects/_table.html.erb
@@ -1,14 +1,14 @@
 <table class="table table-bordered table-striped table-responsive">
   <thead>
     <tr>
-      <th>Id</th>
-      <th>Name</th>
+      <th><%= sortable_header 'Id', 'id' %></th>
+      <th><%= sortable_header 'Name', 'name' %></th>
       <th>Description</th>
-      <th>Website</th>
+      <th><%= sortable_header 'Website', 'homepage_url' %></th>
       <th>License</th>
       <th>Owner</th>
-      <th>Achieved at</th>
-      <th>% Achieved</th>
+      <th><%= sortable_header 'Achieved at', 'achieved_passing_at' %></th>
+      <th><%= sortable_header '% Achieved', 'badge_percentage' %></th>
       <th>Badge</th>
     </tr>
   </thead>
@@ -43,3 +43,12 @@
     <% end %>
   </tbody>
 </table>
+
+<p>
+You can also sort by
+<%= sortable_header 'repository URL', 'repo_url' %>,
+<%= sortable_header 'create time (for the badge entry)', 'created_at' %>,
+<%= sortable_header 'last update time (for the badge entry)', 'updated_at' %>,
+and
+<%= sortable_header 'user id', 'user_id' %>.
+</p>


### PR DESCRIPTION
We've been able to sort projects for a while, and that's
been useful internally. This commit makes it easy to invoke a
sort order from the user interface of /projects.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>