### PR TITLE
Added a criteria of block cipher mode

### DIFF
--- a/doc/criteria.md
+++ b/doc/criteria.md
@@ -518,8 +518,6 @@ by the delivered project's software.
   on cryptography MUST be implementable using FLOSS.  See the
   [*Open Standards Requirement for Software* by the Open Source Initiative](https://opensource.org/osr).
   <sup>[<a href="#crypto_floss">crypto_floss</a>]</sup>
-- <a name="crypto_agility"></a>Cryptographic agility SHOULD be considered during project design. Cryptographic algorithms SHOULD NOT be hard coded. It is SUGGESTED that the cryptographic modules be independent and the cryptographic API be scalable for easy replacement and update.
-  <sup>[<a href="#crypto_agility">crypto_agility</a>]</sup>
 - <a name="crypto_keylength"></a>The project security mechanisms
   MUST use default keylengths that at least
   meet the NIST minimum requirements

--- a/doc/criteria.md
+++ b/doc/criteria.md
@@ -554,6 +554,8 @@ by the delivered project's software.
   iterated hashes with a per-user salt by using a key stretching
   (iterated) algorithm (e.g., PBKDF2, Bcrypt or Scrypt).
   <sup>[<a href="#crypto_password_storage">crypto_password_storage</a>]</sup>
+- <a name="crypto_blockmode"></a>The project SHOULD select the GCM (Galois/Counter Mode) or CBC (Cipher Block Channing) mode when using block ciphers. The ECB mode SHOULD NOT be used directly for cryptographic purposes.
+  <sup>[<a href="#crypto_blockmode">crypto_blockmode</a>]</sup>
 - <a name="crypto_random"></a>The project MUST generate all
   cryptographic keys and nonces
   using a cryptographically secure random number generator,

--- a/doc/criteria.md
+++ b/doc/criteria.md
@@ -518,6 +518,8 @@ by the delivered project's software.
   on cryptography MUST be implementable using FLOSS.  See the
   [*Open Standards Requirement for Software* by the Open Source Initiative](https://opensource.org/osr).
   <sup>[<a href="#crypto_floss">crypto_floss</a>]</sup>
+- <a name="crypto_agility"></a>Cryptographic agility SHOULD be considered during project design. Cryptographic algorithms SHOULD NOT be hard coded. It is SUGGESTED that the cryptographic modules be independent and the cryptographic API be scalable for easy replacement and update.
+  <sup>[<a href="#crypto_agility">crypto_agility</a>]</sup>
 - <a name="crypto_keylength"></a>The project security mechanisms
   MUST use default keylengths that at least
   meet the NIST minimum requirements


### PR DESCRIPTION
Block ciphers support multiple modes which apply to specific scenarios. The GCM mode is recommended when performing authentication and encryption for integrity of plaintext or other authentication data. The CBC mode has better adaptability and most popularity. The ECB mode generates the same cipher block for the same plaintext and therefore does not provide strict data confidentiality or defend against block replacement attacks.