### PR TITLE
Fix issues with testing suite, particularly failures with some seeds 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   gem 'spring', '1.7.2'
   gem 'vcr', '3.0.3' # Record network responses for later test reuse
   gem 'yaml-lint', '0.0.9' # Check YAML file syntax
+  gem 'database_cleaner', '1.5.2' # Cleans up database between tests
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     concurrent-ruby (1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.5.2)
     debug_inspector (0.0.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -436,6 +437,7 @@ DEPENDENCIES
   chartkick (= 2.1.1)
   chromedriver-helper (= 1.0.0)
   codecov (= 0.1.6)
+  database_cleaner (= 1.5.2)
   dotenv-rails (= 2.1.1)
   eslintrb (= 2.1.0)
   faker (= 1.6.6)
@@ -493,4 +495,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.3
+   1.13.5

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,38 +1,6 @@
 # frozen_string_literal: true
 # Rake tasks for BadgeApp
 
-# UGLY work-around for intermittently failing tests, by forcing the test seed.
-# The underlying problem this addresses is that
-# tests intermittently fail (issue #397).  We believe this is because
-# at the end of each test the test framework does a
-# ROLLBACK, but for reasons we've not determined a SAVEPOINT is not always
-# performed at the start of each test (it SHOULD happen!).
-# Intermittent test failures significantly impede development and
-# deployment, because it means that tests will fail even though the
-# software is fine. There's value in doing a random test order, so we try to
-# select randomly between several known-working seeds.
-# The *CORRECT* solution is to fix the problem, but this appears to be
-# a subtle bug in our dependencies. We believe it traces
-# back to vcr; a bug report has been submitted.  Until it's fixed, here's
-# a work-around.
-#
-# NOTE: Changing the test suite may cause a seed to fail, so you'll need to
-# change the seed at that point.  An easy solution is to comment out the
-# line below, run "rake test" many times until you find working seeds
-# that don't trigger "Deleting extra project..." or failing tests,
-# and then set the seed.  We use multiple random seeds, and have other
-# work-arounds in place, so hopefully a test suite change will simply
-# bring us back to intermittent failures until the seeds are reset.
-#
-# For more info:
-# https://github.com/linuxfoundation/cii-best-practices-badge/issues/397
-# https://github.com/vcr/vcr/issues/586
-
-ENV['TESTOPTS'] = "--seed=#{[29_928].sample}"
-
-# Run tests last. That way, runtime problems (e.g., undone migrations)
-# do not interfere with the other checks.
-
 task(:default).clear.enhance %w(
   rbenv_rvm_setup
   bundle

--- a/test/features/github_login_test.rb
+++ b/test/features/github_login_test.rb
@@ -3,6 +3,11 @@ require 'test_helper'
 
 class GithubLoginTest < Capybara::Rails::TestCase
   scenario 'Has link to GitHub Login', js: true do
+    # Clean up database here and restart DatabaseCleaner.
+    # This solves a transient issue if test restarts without running
+    # teardown meaning the database is dirty after restart.
+    DatabaseCleaner.clean
+    DatabaseCleaner.start
     configure_omniauth_mock unless ENV['GITHUB_PASSWORD']
 
     VCR.use_cassette('github_login', allow_playback_repeats: true) do


### PR DESCRIPTION
This fixes issue #397.  I implemented DatabaseCleaner in order to fix the intermittent test issues.  The issue was that the database wasn't being cleaned up after runs using capybara.  Database cleaner is a little slower (~30%), but reliable tests are more important than speedy ones.

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>