### PR TITLE
Fix minor syntax error on identification form

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -141,7 +141,7 @@ This information is used when displaying badge information.
 
       <div class="hidable-text-entry">
       <span>What is the URL for the version control repository
-            (it may the same as the project URL)?</span>
+            (it may be the same as the project URL)?</span>
       <% if is_disabled || repo_disabled%>
         <div class="discussion-markdown">
            <%= link_to_if project.contains_url?(project.repo_url), project.repo_url, project.repo_url, rel: 'nofollow' %>


### PR DESCRIPTION
Hi there! This is a very minor fix, but I noted a mistake when beginning to fill out the identification form. 

![screen shot 2016-12-06 at 12 28 05 pm](https://cloud.githubusercontent.com/assets/13326548/20942279/97103c00-bbaf-11e6-9ac6-18e01d2d3d6e.png)

Question 4 is missing a "be".