### PR TITLE
Speed up tests by only using DatabaseCleaner for Capybara tests

### DIFF
--- a/test/capybara_feature_test.rb
+++ b/test/capybara_feature_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# We use DatabaseCleaner to clean up database between capybara tests.
+require 'test_helper'
+require 'database_cleaner'
+DatabaseCleaner.strategy = :transaction
+
+class CapybaraFeatureTest < Capybara::Rails::TestCase
+  # When using DatabaseCleaner, transactional fixtures must be off.
+  self.use_transactional_fixtures = false
+
+  setup do
+    # Start DatabaseCleaner before each test.
+    DatabaseCleaner.start
+  end
+
+  teardown do
+    # Clean up the database with DatabaseCleaner after each test.
+    DatabaseCleaner.clean
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class UsersControllerTest < ActionController::TestCase
-  def setup
+  setup do
     @user = users(:test_user_melissa)
     @other_user = users(:test_user_mark)
     @admin = users(:admin_user)

--- a/test/features/access_home_test.rb
+++ b/test/features/access_home_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'capybara_feature_test'
 
-class AccessHomeTest < Capybara::Rails::TestCase
+class AccessHomeTest < CapybaraFeatureTest
   test 'sanity' do
     visit root_path
     assert has_content? 'CII Best Practices Badge Program'

--- a/test/features/filter_test.rb
+++ b/test/features/filter_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'capybara_feature_test'
 
-class FilterTest < Capybara::Rails::TestCase
+class FilterTest < CapybaraFeatureTest
   scenario 'Can Filter Projects', js: true do
     visit '/projects'
     assert has_content? 'Add New Project'

--- a/test/features/github_login_test.rb
+++ b/test/features/github_login_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'capybara_feature_test'
 
-class GithubLoginTest < Capybara::Rails::TestCase
+class GithubLoginTest < CapybaraFeatureTest
   scenario 'Has link to GitHub Login', js: true do
     # Clean up database here and restart DatabaseCleaner.
     # This solves a transient issue if test restarts without running

--- a/test/features/login_test.rb
+++ b/test/features/login_test.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'capybara_feature_test'
 include ActionView::Helpers::TextHelper
 
-class LoginTest < Capybara::Rails::TestCase
+class LoginTest < CapybaraFeatureTest
   CHECK = /result_symbol_check/
   DASH = /result_symbol_dash/
   QUESTION = /result_symbol_question/

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class SessionsHelperTest < ActionView::TestCase
-  def setup
+  setup do
     @user = users(:test_user)
     remember(@user)
   end

--- a/test/integration/admin_users_show_test.rb
+++ b/test/integration/admin_users_show_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class AdminUsersShowTest < ActionDispatch::IntegrationTest
-  def setup
+  setup do
     @user = users(:test_user)
     @admin_user = users(:admin_user)
     @melissa = users(:test_user_melissa)

--- a/test/integration/feed_test.rb
+++ b/test/integration/feed_test.rb
@@ -3,7 +3,12 @@ require 'test_helper'
 load 'Rakefile'
 
 class FeedTest < ActionDispatch::IntegrationTest
-  def setup
+  # Turn off transactional fixtures for this test since we are loading
+  # the fixtures database anyway. This will prevent the timestamp change
+  # from spilling into other tests.
+  self.use_transactional_fixtures = false
+
+  setup do
     # Normalize time in order to match fixture file
     travel_to Time.zone.parse('2015-03-01T12:00:00') do
       silence_stream(STDOUT) do

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class PasswordResetsTest < ActionDispatch::IntegrationTest
-  def setup
+  setup do
     ActionMailer::Base.deliveries.clear
     @user = users(:test_user)
     @ghuser = users(:github_user)

--- a/test/integration/project_list_test.rb
+++ b/test/integration/project_list_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class ProjectListTest < ActionDispatch::IntegrationTest
-  def setup
+  setup do
     # @user = users(:test_user)
   end
 

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class UsersEditTest < ActionDispatch::IntegrationTest
-  def setup
+  setup do
     @user = users(:test_user)
   end
 

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class UsersEditTest < ActionDispatch::IntegrationTest
-  def setup
+  setup do
     @user = users(:test_user)
     @admin_user = users(:admin_user)
   end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class UsersLoginTest < ActionDispatch::IntegrationTest
-  def setup
+  setup do
     @user = users(:test_user)
     @user2 = users(:test_user_not_active)
   end

--- a/test/integration/users_manipulate_project_test.rb
+++ b/test/integration/users_manipulate_project_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class UsersManipulateProjectTest < ActionDispatch::IntegrationTest
-  def setup
+  setup do
     @user = users(:test_user)
   end
 

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
-  def setup
+  setup do
     ActionMailer::Base.deliveries.clear
   end
 

--- a/test/models/project_stat_test.rb
+++ b/test/models/project_stat_test.rb
@@ -3,16 +3,7 @@
 require 'test_helper'
 
 class ProjectStatTest < ActiveSupport::TestCase
-  def setup
-    # Temporary fix for issue #397
-    # This deletes an extra record introduced by VCR with some test seeds
-    # Repeated here because this runs before test_helper setup
-    unless Project.count == 4
-      p "Deleting extra project. #{Project.count} projects in #{method_name}"
-      Project.where(name: 'Core Infrastructure Initiative Best Practices Badge')
-             .destroy_all
-    end
-
+  setup do
     # Normalize time in order to test timestamps
     travel_to Time.zone.parse('2015-03-01T12:00:00') do
       @project_stat = ProjectStat.create!

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class ProjectTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @user = users(:test_user)
     @project = @user.projects.build(
       homepage_url: 'https://www.example.org',

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @user = User.new(
       name: 'Example User', email: 'user@example.com',
       password: 'p@$$w0rd', password_confirmation: 'p@$$w0rd'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,12 +51,6 @@ VCR.configure do |config|
   config.hook_into :webmock
 end
 
-# We use DatabaseCleaner to clean up database between tests.
-# This is a little bit slower but avoids issues with tests
-# ran using capybara.
-require 'database_cleaner'
-DatabaseCleaner.strategy = :transaction
-
 require 'minitest/rails/capybara'
 
 driver = ENV['DRIVER'].try(:to_sym)
@@ -100,19 +94,8 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical
     # order.
     ActiveRecord::Migration.maintain_test_schema!
-    # When using DatabaseCleaner, transactional fixtures must be off.
-    self.use_transactional_fixtures = false
+    self.use_transactional_fixtures = true
     fixtures :all
-
-    def setup
-      # Start DatabaseCleaner before each test.
-      DatabaseCleaner.start
-    end
-
-    teardown do
-      # Clean up the database with DatabaseCleaner after each test.
-      DatabaseCleaner.clean
-    end
 
     # Add more helper methods to be used by all tests here...
 

--- a/test/unit/lib/blank_detective_test.rb
+++ b/test/unit/lib/blank_detective_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class BlankDetectiveTest < ActiveSupport::TestCase
-  def setup
+  setup do
     # @user = User.new(name: 'Example User', email: 'user@example.com',
     #                 password: 'p@$$w0rd', password_confirmation: 'p@$$w0rd')
   end

--- a/test/unit/lib/build_detective_test.rb
+++ b/test/unit/lib/build_detective_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class BuildDetectiveTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @full_name = 'linuxfoundation/cii-best-practices-badge'
     @human_name = 'Core Infrastructure Initiative Best Practices Badge'
     @evidence = Evidence.new({})

--- a/test/unit/lib/chief_test.rb
+++ b/test/unit/lib/chief_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class ChiefTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @full_name = 'linuxfoundation/cii-best-practices-badge'
     @human_name = 'Core Infrastructure Initiative Best Practices Badge'
 

--- a/test/unit/lib/floss_license_detective_test.rb
+++ b/test/unit/lib/floss_license_detective_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class FlossLicenseDetectiveTest < ActiveSupport::TestCase
-  def setup
+  setup do
     # @user = User.new(name: 'Example User', email: 'user@example.com',
     #                 password: 'p@$$w0rd', password_confirmation: 'p@$$w0rd')
   end

--- a/test/unit/lib/github_basic_detective_test.rb
+++ b/test/unit/lib/github_basic_detective_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class GithubBasicDetectiveTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @full_name = 'linuxfoundation/cii-best-practices-badge'
     @human_name = 'Core Infrastructure Initiative Best Practices Badge'
     @evidence = Evidence.new({})

--- a/test/unit/lib/name_from_url_detective_test.rb
+++ b/test/unit/lib/name_from_url_detective_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class NameFromUrlDetectiveTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @evidence = Evidence.new({})
   end
 


### PR DESCRIPTION
This takes test speed performance back on par with what it was before the seeding issue was fixed.  Instead of running database cleaner between each test, we now only run it for tests which involve Capybara.  

This did produce an issue when running feed_test.rb since it reloads the database at a fixed time and thus muddies the time stamps in the database. This was fixed by turning off use_transactional_fixtures for that test only.    

I also did a little bit of test cleanup so we now make callbacks to setup rather than overwriting the setup method when our tests need special setup features.   