### PR TITLE
Tweak sites_https: CloudFlare CDN is okay for GitHub pages + custom d…

### DIFF
--- a/criteria.yml
+++ b/criteria.yml
@@ -225,6 +225,15 @@
         details: >
           You can get free certificates from
           <a href="https://letsencrypt.org/">Let's Encrypt</a>.
+          If you are using GitHub pages without a custom domain, you can simply
+          <a href="https://help.github.com/articles/securing-your-github-pages-site-with-https/">change its settings to enforce HTTPS</a>.
+          If you are using GitHub pages with a custom
+          domain, you MAY use a content delivery network
+          (CDN) such as CloudFlare as a proxy to support HTTPS; see <a
+          href=”https://blog.cloudflare.com/secure-and-fast-github-pages-with-cloudflare/”>Secure
+          and fast GitHub Pages with CloudFlare</a>.
+          A project MAY also support HTTP, though we
+          encourage users to use HTTPS instead.
         autofill: >
           Look at project, repo, and download URLs. https is okay, http is not.
           Typically anything supporting HTTPS also supports TLS, so


### PR DESCRIPTION
…omains

Many projects use GitHub pages with custom domains.
GitHub pages support HTTPS, but only if there are no custom domains.
GitHub does not directly support HTTPS for custom domains, but there is
a workaround involving using a CDN (such as CloudFlare) as a proxy.
Make it clear that this workaround is fine.  While we're at it,
give guidance for people who use GitHub pages without custom domains,
and make it clear that supporting HTTP is *permitted*
(we just require that they support HTTPS).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>