### PR TITLE
Make private methods private (and alphabetize)

### DIFF
--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -263,7 +263,7 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'sanity test of reminders' do
-    result = ProjectsController.send_reminders
+    result = ProjectsController.send :send_reminders
     assert_equal 1, result.size
   end
 end


### PR DESCRIPTION
Signed-off-by: Dan Kohn <dan@dankohn.com>

Methods that don't need to be exposed to the scary web shouldn't be. Note the test change to allow testing a now private method. This is expected to be merged after dan-other-gems.