### PR TITLE
Remove "Style/NegatedIf" so we don't *have* to use "unless"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,8 @@ Style/FirstMethodParameterLineBreak:
   Enabled: true
 Style/MultilineAssignmentLayout:
   Enabled: true
+Style/NegatedIf:
+  Enabled: false
 Style/OptionHash:
   Enabled: true
 Style/StringMethods:


### PR DESCRIPTION
  The rubocop rule "Style/NegatedIf" *requires* that we use
  "unless" instead of "if !...".  I think we should drop this rule;
  neither Jason or I think it's adding value.  This commit
  allows us to use *either* "unless" or "if !".

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>