### PR TITLE
New password rules (NIST SP 800-63B)

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -23,7 +23,7 @@ class PasswordResetsController < ApplicationController
     if params[:user][:password].empty?
       @user.errors.add(:password, 'can\'t be empty')
       render 'edit'
-    elsif !@user.valid_password?(params[:user][:password])
+    elsif !@user.password_valid?(params[:user][:password])
       @user.errors.add(
         :password,
         'doesnt meet our complexity/length requirements'

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -18,13 +18,16 @@ class PasswordResetsController < ApplicationController
 
   def edit; end
 
+  # rubocop: disable Metrics/MethodLength,Metrics/AbcSize
   def update
     if params[:user][:password].empty?
       @user.errors.add(:password, 'can\'t be empty')
       render 'edit'
-    elsif !User.valid_password?(params[:user][:password])
-      @user.errors.add(:password, 'doesnt meet our complexity/length  
-                                   requirements')
+    elsif !@user.valid_password?(params[:user][:password])
+      @user.errors.add(
+        :password,
+        'doesnt meet our complexity/length requirements'
+      )
       render 'edit'
     elsif @user.update_attributes(user_params)
       log_in @user
@@ -34,6 +37,7 @@ class PasswordResetsController < ApplicationController
       render 'edit'
     end
   end
+  # rubocop: enable Metrics/MethodLength,Metrics/AbcSize
 
   private
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -22,6 +22,10 @@ class PasswordResetsController < ApplicationController
     if params[:user][:password].empty?
       @user.errors.add(:password, 'can\'t be empty')
       render 'edit'
+    elsif !User.valid_password?(params[:user][:password])
+      @user.errors.add(:password, 'doesnt meet our complexity/length  
+                                   requirements')
+      render 'edit'
     elsif @user.update_attributes(user_params)
       log_in @user
       flash[:success] = 'Password has been reset'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -48,9 +48,15 @@ class SessionsController < ApplicationController
   def local_login_procedure(user)
     if user.activated?
       log_in user
-      redirect_back_or root_url
-      flash[:success] = 'Signed in!'
       params[:session][:remember_me] == '1' ? remember(user) : forget(user)
+      if password_valid?(params[:session][:password])
+        redirect_back_or root_url
+        flash[:success] = 'Signed in!'
+      else
+        flash[:warning] = 'Your password does not meet our new requirements.
+                           We strongly suggest you change it.'
+        redirect_to edit_user_path(user)
+      end
     else
       flash[:warning] = 'Account not activated.
                          Check your email for the activation link.'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -45,6 +45,7 @@ class SessionsController < ApplicationController
     flash[:success] = 'Signed in!'
   end
 
+  # rubocop: disable Metrics/MethodLength,Metrics/AbcSize
   def local_login_procedure(user)
     if user.activated?
       log_in user
@@ -63,4 +64,5 @@ class SessionsController < ApplicationController
       redirect_to root_url
     end
   end
+  # rubocop: ensable Metrics/MethodLength,Metrics/AbcSize
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -54,8 +54,8 @@ class SessionsController < ApplicationController
         redirect_back_or root_url
         flash[:success] = 'Signed in!'
       else
-        flash[:warning] = 'Your password does not meet our new requirements.
-                           We strongly suggest you change it.'
+        flash[:danger] = 'Your password does not meet our new requirements.
+                          We strongly suggest you change it.'
         redirect_to edit_user_path(user)
       end
     else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -49,7 +49,7 @@ class SessionsController < ApplicationController
     if user.activated?
       log_in user
       params[:session][:remember_me] == '1' ? remember(user) : forget(user)
-      if password_valid?(params[:session][:password])
+      if user.password_valid?(params[:session][:password])
         redirect_back_or root_url
         flash[:success] = 'Signed in!'
       else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
     @edit_projects = Project.where(repo_url: github_user_projects) - @projects
   end
 
-  # rubocop: disable Metrics/MethodLength
+  # rubocop: disable Metrics/MethodLength,Metrics/AbcSize
   def create
     @user = User.find_by(email: user_params[:email])
     if @user
@@ -28,19 +28,20 @@ class UsersController < ApplicationController
     else
       @user = User.new(user_params)
       @user.provider = 'local'
-      if User.password_valid?(user_params[:password])
+      if @user.password_valid?(user_params[:password])
         if @user.save
           send_activation
         else
           render 'new'
         end
       else
-        flash.now[:warning] = 'Your password does not meet our
-                               complexity/lenght requirements.'
+        flash.now[:danger] = 'Your password does not meet our
+                              complexity/length requirements.'
+        render 'new'
       end
     end
   end
-  # rubocop: enable Metrics/MethodLength
+  # rubocop: enable Metrics/MethodLength,Metrics/AbcSize
 
   def edit
     @user = User.find(params[:id])
@@ -53,7 +54,7 @@ class UsersController < ApplicationController
     if !@user.password_valid?(user_params[:password])
       flash.now[:danger] =
         'Your new password does not meet our
-        complexity/length requirements.'
+         complexity/length requirements.'
       render 'edit'
     elsif @user.update_attributes(user_params)
       flash[:success] = 'Profile updated'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,15 +28,15 @@ class UsersController < ApplicationController
     else
       @user = User.new(user_params)
       @user.provider = 'local'
-      if password_valid?(user_params[:password])
+      if User.password_valid?(user_params[:password])
         if @user.save
           send_activation
         else
           render 'new'
-      else 
-        flash.now[:warning] = 'Your password does not meet our new
-                               requirements.  We strongly suggest you 
-                               change it.'
+        end
+      else
+        flash.now[:warning] = 'Your password does not meet our
+                               complexity/lenght requirements.'
       end
     end
   end
@@ -47,15 +47,22 @@ class UsersController < ApplicationController
     redirect_to @user unless @user.provider == 'local'
   end
 
+  # rubocop: disable Metrics/MethodLength Metrics/AbcSize
   def update
     @user = User.find(params[:id])
-    if @user.update_attributes(user_params)
+    if !@user.password_valid?(user_params[:password])
+      flash.now[:danger] =
+        'Your new password does not meet our
+        complexity/length requirements.'
+      render 'edit'
+    elsif @user.update_attributes(user_params)
       flash[:success] = 'Profile updated'
       redirect_to @user
     else
       render 'edit'
     end
   end
+  # rubocop: enable Metrics/MethodLength Metrics/AbcSize
 
   def destroy
     User.find(params[:id]).destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,10 +28,15 @@ class UsersController < ApplicationController
     else
       @user = User.new(user_params)
       @user.provider = 'local'
-      if @user.save
-        send_activation
-      else
-        render 'new'
+      if password_valid?(user_params[:password])
+        if @user.save
+          send_activation
+        else
+          render 'new'
+      else 
+        flash.now[:warning] = 'Your password does not meet our new
+                               requirements.  We strongly suggest you 
+                               change it.'
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
     redirect_to @user unless @user.provider == 'local'
   end
 
-  # rubocop: disable Metrics/MethodLength Metrics/AbcSize
+  # rubocop: disable Metrics/MethodLength,Metrics/AbcSize
   def update
     @user = User.find(params[:id])
     if !@user.password_valid?(user_params[:password])
@@ -62,7 +62,7 @@ class UsersController < ApplicationController
       render 'edit'
     end
   end
-  # rubocop: enable Metrics/MethodLength Metrics/AbcSize
+  # rubocop: enable Metrics/MethodLength,Metrics/AbcSize
 
   def destroy
     User.find(params[:id]).destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,13 +5,12 @@ class User < ActiveRecord::Base
   attr_accessor :remember_token, :activation_token, :reset_token
   before_create :create_activation_digest
 
-  MIN_PASSWORD_LENGTH = 7
+  MIN_PASSWORD_LENGTH = 8
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, length: { maximum: 255 },
                     uniqueness: { case_sensitive: false }, email: true
   validates :password, presence: true,
-                       length: { minimum: MIN_PASSWORD_LENGTH },
                        allow_nil: true
 
   # Returns the hash digest of the given string.
@@ -45,6 +44,11 @@ class User < ActiveRecord::Base
   # Sends activation email.
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  def password_valid?(password)
+    return false if password < MIN_PASSWORD_LENGTH
+    !BadPasswordSet.include?(value.downcase)
   end
 
   # Sets the password reset attributes.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,8 +47,8 @@ class User < ActiveRecord::Base
   end
 
   def password_valid?(password)
-    return false if password < MIN_PASSWORD_LENGTH
-    !BadPasswordSet.include?(value.downcase)
+    return false if password.length < MIN_PASSWORD_LENGTH
+    !BadPasswordSet.include?(password.downcase)
   end
 
   # Sets the password reset attributes.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,9 +46,10 @@ class User < ActiveRecord::Base
     UserMailer.account_activation(self).deliver_now
   end
 
-  def password_valid?(password)
-    return false if password.length < MIN_PASSWORD_LENGTH
-    !BadPasswordSet.include?(password.downcase)
+  def password_valid?(value)
+    return true if value.blank?
+    return false if value.length < MIN_PASSWORD_LENGTH
+    !BadPasswordSet.include?(value.downcase)
   end
 
   # Sets the password reset attributes.

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -58,13 +58,43 @@ class PasswordResetsControllerTest < ActionController::TestCase
       }
     }
     assert_select 'div#error_explanation'
-    # Valid password & confirmation
+    # password too short
     patch :update, params: {
       id: user.reset_token,
       email: user.email,
       user: {
         password:              'foo1234',
         password_confirmation: 'foo1234'
+      }
+    }
+    assert_select 'div#error_explanation'
+    # password not complex
+    patch :update, params: {
+      id: user.reset_token,
+      email: user.email,
+      user: {
+        password:              'password',
+        password_confirmation: 'password'
+      }
+    }
+    assert_select 'div#error_explanation'
+    # Valid password, invalid confirm
+    patch :update, params: {
+      id: user.reset_token,
+      email: user.email,
+      user: {
+        password:              'foo12345',
+        password_confirmation: 'foo123467'
+      }
+    }
+    assert_select 'div#error_explanation'
+    # Valid password & confirmation
+    patch :update, params: {
+      id: user.reset_token,
+      email: user.email,
+      user: {
+        password:              'foo12345',
+        password_confirmation: 'foo12345'
       }
     }
     assert user_logged_in?

--- a/test/features/login_test.rb
+++ b/test/features/login_test.rb
@@ -22,7 +22,7 @@ class LoginTest < CapybaraFeatureTest
   scenario 'Can Login and edit using custom account', js: true do
     visit login_path
     fill_in 'Email', with: @user.email
-    fill_in 'Password', with: 'password'
+    fill_in 'Password', with: 'pa$$word'
     click_button 'Log in using custom account'
     assert has_content? 'Signed in!'
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,7 @@
 test_user:
   name: Test
   email: test@example.org
-  password_digest: <%= User.digest('password') %>
+  password_digest: <%= User.digest('pa$$word') %>
   provider: local
   activated: true
   activated_at: <%= Time.zone.now %>
@@ -11,7 +11,7 @@ test_user:
 test_user_melissa:
   name: Melissa Lewis
   email: melissa@example.com
-  password_digest: <%= User.digest('password1') %>
+  password_digest: <%= User.digest('pa$$word1') %>
   provider: local
   activated: true
   activated_at: <%= Time.zone.now %>
@@ -27,14 +27,14 @@ test_user_mark:
 test_user_not_active:
   name: Forgetful
   email: forgetful@example.com
-  password_digest: <%= User.digest('password') %>
+  password_digest: <%= User.digest('pa$$word') %>
   provider: local
   activated: false
 
 test_user_cs:
   name: Case Sensitive
   email: CaseSensitive@example.org
-  password_digest: <%= User.digest('password') %>
+  password_digest: <%= User.digest('pa$$word') %>
   provider: local
   activated: true
   activated_at: <%= Time.zone.now %>
@@ -42,7 +42,7 @@ test_user_cs:
 admin_user:
   name: Admin
   email: admin@example.com
-  password_digest: <%= User.digest('password') %>
+  password_digest: <%= User.digest('pa$$word') %>
   provider: local
   activated: true
   activated_at: <%= Time.zone.now %>

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -6,15 +6,26 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     @user = users(:test_user)
   end
 
-  test 'unsuccessful edit' do
+  test 'unsuccessful edit, bad password' do
+    log_in_as(@user)
+    get edit_user_path(@user)
+    assert_template 'users/edit'
+    patch user_path(@user), params: { user: {
+      name:  @user.name,
+      email: @user.email,
+      password:              'password',
+      password_confirmation: 'password'
+    } }
+    assert_template 'users/edit'
+  end
+
+  test 'unsuccessful edit, bad name and email' do
     log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
     patch user_path(@user), params: { user: {
       name:  '',
-      email: 'foo@invalid',
-      password:              '12a',
-      password_confirmation: '45b'
+      email: 'foo@invalid'
     } }
     assert_template 'users/edit'
   end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -5,6 +5,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:test_user)
     @user2 = users(:test_user_not_active)
+    @user3 = users(:test_user_mark)
   end
 
   test 'login with invalid username and password' do
@@ -29,6 +30,23 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
       session: { email: 'unknown@example.org', password: 'bad_password' }
     }
     assert_template 'sessions/new'
+    assert_not flash.empty?
+    get root_path
+    assert flash.empty?
+  end
+
+  test 'login with simple password' do
+    get login_path
+    assert_template 'sessions/new'
+    post login_path, params: {
+      session: {
+        email: @user3.email, password: 'password',
+        provider: @user3.provider
+      }
+    }
+    assert user_logged_in?
+    assert_redirected_to edit_user_path(@user3)
+    follow_redirect!
     assert_not flash.empty?
     get root_path
     assert flash.empty?

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
 
+# rubocop:disable Metrics/ClassLength
 class UsersSignupTest < ActionDispatch::IntegrationTest
   setup do
     ActionMailer::Base.deliveries.clear
@@ -11,36 +12,36 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
       post users_path, params: { user: {
         name:  '',
         email: 'user@invalid',
-        password:              'foo',
-        password_confirmation: 'bar'
+        password:              'p@ssword',
+        password_confirmation: 'p@ssword'
       } }
     end
     assert_template 'users/new'
   end
 
-  #   test 'too-short password' do
-  #     assert_no_difference 'User.count' do
-  #       post users_path, user: {
-  #         name:  'Example User',
-  #         email: 'user@example.com',
-  #         password:              '1234567',
-  #         password_confirmation: '1234567'
-  #       }
-  #     end
-  #     assert_template 'users/new'
-  #   end
-  #
-  #   test 'too-easy password' do
-  #     assert_no_difference 'User.count' do
-  #       post users_path, user: {
-  #         name:  'Example User',
-  #         email: 'user@example.com',
-  #         password:              'password',
-  #         password_confirmation: 'password'
-  #       }
-  #     end
-  #     assert_template 'users/new'
-  #   end
+  test 'too-short password' do
+    assert_no_difference 'User.count' do
+      post users_path, params: { user: {
+        name:  'Example User',
+        email: 'user@example.com',
+        password:              '1234567',
+        password_confirmation: '1234567'
+      } }
+    end
+    assert_template 'users/new'
+  end
+
+  test 'too-easy password' do
+    assert_no_difference 'User.count' do
+      post users_path, params: { user: {
+        name:  'Example User',
+        email: 'user@example.com',
+        password:              'password',
+        password_confirmation: 'password'
+      } }
+    end
+    assert_template 'users/new'
+  end
 
   test 'valid signup information with account activation' do
     get signup_path
@@ -120,3 +121,4 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_not user_logged_in?
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -75,7 +75,7 @@ class UserTest < ActiveSupport::TestCase
 
   test 'password should have a minimum length' do
     @user.password = @user.password_confirmation = 'a' * 6
-    assert_not @user.valid?
+    assert_not @user.password_valid?(@user.password)
   end
 
   test 'associated projects should be destroyed' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -132,7 +132,7 @@ module ActiveSupport
     # Using "password" helps test that users can log in to their
     # existing accounts, even if we make the password rules harsher later.
     def log_in_as(
-      user, password: 'password', provider: 'local', remember_me: '1',
+      user, password: 'pa$$word', provider: 'local', remember_me: '1',
       time_last_used: Time.now.utc
     )
       # This is based on "Ruby on Rails Tutorial" by Michael Hargle, chapter 8,


### PR DESCRIPTION
This branch implements in a working way the new NIST SP 800-63B password requirements, addressing issue #545.

Instead of using a validator, passwords are checked on submission against the new requirements.  

Existing users with bad passwords will be redirected to their user edit path upon login and are encouraged to change their current passwords.

New users are not allowed to have bad passwords and existing users cannot change their passwords to a bad password.