### PR TITLE
Add pkg-config to required packages for Ubuntu flavors.

### DIFF
--- a/install-badge-dev-env
+++ b/install-badge-dev-env
@@ -159,7 +159,8 @@ case "$manager" in
     #         libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev \
     #         libgdbm3 libgdbm-dev
     add_pkg ruby-build postgresql-server-dev-all postgresql \
-            postgresql-contrib cmake nodejs phantomjs graphviz ;;
+            postgresql-contrib cmake nodejs phantomjs graphviz \
+            pkg-config;;
   yum|dnf)
     add_pkg gcc openssl-devel libyaml-devel libffi-devel readline-devel \
             zlib-devel gdbm-devel ncurses-devel postgresql-devel cmake npm \


### PR DESCRIPTION
The gem rugged requires pkg-config to be installed.  Not all Ubuntu flavors have this package installed by default (Xubuntu, for example) so we should make sure it gets installed.

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>