### PR TITLE
Fixes for 404 pages to ignore formats

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -13,6 +13,10 @@ class StaticPagesController < ApplicationController
     # You can do something like this to log more information, but be sure
     # to escape attacker data to counter log forging:
     # logger.info 'Page not found'
-    render status: 404
+    render(
+      template: 'static_pages/error_404',
+      layout: false,
+      status: 404
+    )
   end
 end

--- a/app/views/static_pages/error_404.html
+++ b/app/views/static_pages/error_404.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <title>Error 404 (Not Found)!!</title>
+  <h1>
+    ERROR
+    <br>404 - File not found
+  </h1>
+</html>

--- a/app/views/static_pages/error_404.html.erb
+++ b/app/views/static_pages/error_404.html.erb
@@ -1,6 +1,0 @@
-<div class="center jumbotron">
-<h1>ERROR</h1>
-<h2>404 - File not found</h2>
-<h3><%=request.original_url %></h3>
-<h3>Sorry, we could not find the above page on our servers.</h3>
-</div>


### PR DESCRIPTION
This fixes errors with the 404 page when a format other than html was requested.  #604 

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>