### PR TITLE
Preserve edit in url on failed edit

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -83,7 +83,7 @@ There is also a
 <div class="row">
   <div class="col-md-12">
 
-  <%= bootstrap_form_for(project) do |f| %>
+  <%= bootstrap_form_for project, url: put_project_path(project) do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <%= f.hidden_field :lock_version %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   resources :project_stats
   get 'sessions/new'
@@ -20,8 +21,10 @@ Rails.application.routes.draw do
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: %i(new create edit update)
   resources :projects
-  match 'projects/:id/edit' => 'projects#update', :via => [:put, :patch], :as => :put_project
-
+  match(
+    'projects/:id/edit' => 'projects#update',
+    :via => %i(put patch), :as => :put_project
+  )
   get 'login' => 'sessions#new'
   post 'login' => 'sessions#create'
   delete 'logout' => 'sessions#destroy'
@@ -103,3 +106,4 @@ Rails.application.routes.draw do
   match 'wp-login.php', via: :all, to: 'static_pages#error_404'
   match '.well-known/*path', via: :all, to: 'static_pages#error_404'
 end
+# rubocop:enable Metrics/BlockLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
   resources :users
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: %i(new create edit update)
+  resources :projects
+  match 'projects/:id/edit' => 'projects#update', :via => [:put, :patch], :as => :put_project
 
   get 'login' => 'sessions#new'
   post 'login' => 'sessions#create'


### PR DESCRIPTION
This resolves #632. 

I had to adjust the routes a bit, but got it to work.  

http://stackoverflow.com/questions/4707471/render-template-and-change-url-string-in-browser was quite helpful. 

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>