### PR TITLE
Removed hide_label attributes the were not valid HTML

### DIFF
--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -39,13 +39,13 @@
       <span>What is the URL for the project home page (the URL for the project as a whole)? Start with http(s):// (many characters are not allowed, including "?")</span>
       <!-- Note: Server tests URLs, this is just sanity checking -->
       <%= f.text_field :homepage_url, class:"form-control",
-            type: 'url', hide_label: true,
+            type: 'url',
             pattern: url_pattern,
             placeholder:'http(s)://... for project home page URL' %>
       <span>What is the URL for the version control repository
             (it may the same as the project home page)? Start with http(s):// (many characters are not allowed, including "?")</span>
       <%= f.text_field :repo_url, class:"form-control",
-            type: 'url', hide_label: true,
+            type: 'url', 
             pattern: url_pattern,
             placeholder:'http(s)://... for project repo URL' %>
      <%= f.submit 'Submit URL', class: 'btn btn-primary',


### PR DESCRIPTION
These attributes are ruby/bootstrap but the validater sees them as bad HTML. I tried removing them and it seem to make no change. I think they were not needed and are just boilerplate.