### PR TITLE
Redirect to previous url on login

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -78,8 +78,9 @@ module SessionsHelper
   # Stores the URL trying to be accessed
   def store_location
     session.delete(:forwarding_url)
+    return if request.referer.nil? || !request.get?
     return unless refered_from_our_site?
-    url = request.referer if request.get?
+    url = request.referer
     session[:forwarding_url] = url unless url == login_url
   end
 
@@ -101,14 +102,8 @@ module SessionsHelper
 
   private
 
-  def http_referer_uri
-    return if request.env['HTTP_REFERER'].nil?
-    URI.parse(request.env['HTTP_REFERER'])
-  end
-
   def refered_from_our_site?
-    uri = http_referer_uri
-    return false if uri.nil?
-    uri.host == request.host
+    return false if request.referer.nil?
+    URI.parse(request.referer).host == request.host
   end
 end

--- a/test/features/login_test.rb
+++ b/test/features/login_test.rb
@@ -13,18 +13,18 @@ class LoginTest < CapybaraFeatureTest
     @project = projects(:one)
   end
 
-  scenario 'Has link to GitHub Login', js: true do
-    visit login_path
-    assert has_content? 'Log in with GitHub'
-  end
-
   # rubocop:disable Metrics/BlockLength
   scenario 'Can Login and edit using custom account', js: true do
-    visit login_path
+    visit projects_path
+    click_on 'Login'
     fill_in 'Email', with: @user.email
     fill_in 'Password', with: 'password'
     click_button 'Log in using custom account'
     assert has_content? 'Signed in!'
+    assert_equal current_path, projects_path
+    # Check we are redirected back to root if we try to get login again
+    visit login_path
+    assert_equal current_path, root_path
 
     visit edit_project_path(@project)
     kill_sticky_headers # This is necessary for Chrome and Firefox


### PR DESCRIPTION
When a user logs in from a page other than the root url of the site, lets redirect them back to where they were.  Also redirect logged in users back to the root_url if they try to get /login.

This fixes Issue #635 