### PR TITLE
Redirect back to projects/new after signin from projects/new

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -65,6 +65,7 @@ class ProjectsController < ApplicationController
 
   # GET /projects/new
   def new
+    store_location
     @project = Project.new
   end
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -75,13 +75,15 @@ module SessionsHelper
     session.delete(:forwarding_url)
   end
 
-  # Stores the URL trying to be accessed
+  # Stores the URL trying to be accessed (if its a new project) or a referer
   def store_location
     session.delete(:forwarding_url)
-    return if request.referer.nil? || !request.get?
-    return unless refered_from_our_site?
-    url = request.referer
-    session[:forwarding_url] = url unless url == login_url
+    return unless request.get?
+    if request.url == new_project_url
+      session[:forwarding_url] = new_project_url
+    else
+      store_internal_referer
+    end
   end
 
   def session_expired
@@ -102,8 +104,10 @@ module SessionsHelper
 
   private
 
-  def refered_from_our_site?
-    return false if request.referer.nil?
-    URI.parse(request.referer).host == request.host
+  def store_internal_referer
+    return if request.referer.nil?
+    ref_url = request.referer
+    return unless URI.parse(ref_url).host == request.host
+    session[:forwarding_url] = ref_url unless ref_url == login_url
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -104,6 +104,7 @@ module SessionsHelper
 
   private
 
+  # Check if refering url is internal, if so, save it.
   def store_internal_referer
     return if request.referer.nil?
     ref_url = request.referer

--- a/test/features/github_login_test.rb
+++ b/test/features/github_login_test.rb
@@ -30,6 +30,7 @@ class GithubLoginTest < CapybaraFeatureTest
 
       assert_equal num + 1, ActionMailer::Base.deliveries.size
       assert has_content? 'Signed in!'
+      # Regression test, make sure redirected correctly after login
       assert_equal current_path, new_project_path
       assert find(
         "option[value='https://github.com/ciitest/test-repo']"

--- a/test/features/github_login_test.rb
+++ b/test/features/github_login_test.rb
@@ -15,6 +15,7 @@ class GithubLoginTest < CapybaraFeatureTest
       visit '/'
       assert has_content? 'CII Best Practices Badge Program'
       click_on 'Get Your Badge Now!'
+      assert_equal current_path, new_project_path
       assert has_content? 'Log in with GitHub'
       num = ActionMailer::Base.deliveries.size
       click_link 'Log in with GitHub'
@@ -29,8 +30,7 @@ class GithubLoginTest < CapybaraFeatureTest
 
       assert_equal num + 1, ActionMailer::Base.deliveries.size
       assert has_content? 'Signed in!'
-      click_on 'Get Your Badge Now!'
-      wait_for_url '/projects/new?'
+      assert_equal current_path, new_project_path
       assert find(
         "option[value='https://github.com/ciitest/test-repo']"
       )


### PR DESCRIPTION
If a user clicked the "Big green button" (Get your badge now) and were not signed in, they would be asked to login but then redirected back to the homepage. This makes it so they are redirected back to projects/new after logging in.