### PR TITLE
Indicate badge entry data is licensed as CC-BY-3.0+ from now on

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -293,6 +293,14 @@ class Project < ActiveRecord::Base
     ReportMailer.email_new_project_owner(self).deliver_now
   end
 
+  # Return true if we should show an explicit license for the data.
+  # Old entries did not set a license; we only want to show entry licenses
+  # if the updated_at field indicates there was agreement to it.
+  ENTRY_LICENSE_EXPLICIT_DATE = DateTime.iso8601('2017-02-20T12:00Z')
+  def show_entry_license?
+    updated_at >= ENTRY_LICENSE_EXPLICIT_DATE
+  end
+
   private
 
   def all_active_criteria_passing?

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -596,7 +596,25 @@ provided by the delivered project's software.
 </div>
       <br>
       <div class="center">
-      <% if ! is_disabled %>
+      <% if is_disabled %>
+        <% if project.show_entry_license? %>
+          This data is available under the
+          <a href="https://creativecommons.org/licenses/by/3.0/us"
+          target="_blank">Creative Commons Attribution version 3.0 or later
+          license (CC-BY-3.0+)</a>; all are free to share
+          and adapt the data, but must give appropriate credit.
+          Please credit <%= project.user.name %> and
+          the CII Best Practices badge contributors.<br><br>
+        <% end %>
+      <% else %>
+        By submitting this data about the project you agree to release it
+        under at least the
+        <a href="https://creativecommons.org/licenses/by/3.0/us"
+        target="_blank">Creative Commons Attribution version 3.0 or later
+        license (CC-BY-3.0+)</a>. This means that all are free to share
+        and adapt the data, but they must give appropriate credit.
+        You retain copyright (if any), and the project
+        license is unaffected.<br><br>
         <%= f.submit 'Save (and continue)', name: 'continue', class:"btn btn-primary btn-submit" %>
         <%= f.submit 'Submit (and exit)', class:"btn btn-primary btn-submit" %>
       <% end %>

--- a/app/views/projects/index.json.jbuilder
+++ b/app/views/projects/index.json.jbuilder
@@ -1,4 +1,14 @@
 json.array!(@projects) do |project|
   json.merge! project.attributes
   json.url project_url(project, format: :json)
+  if project.show_entry_license?
+    json.project_entry_license 'CC-BY-3.0+'
+    json.project_entry_attribution ('Please credit '.html_safe +
+                                    project.user.name +
+                                    ' and the CII Best Practices badge' +
+                                    ' contributors.')
+  end
+  # json.database_license 'CC-BY-3.0+'
+  # json.database_attribution ('Please credit the CII Best Practices badge' +
+  #                            ' contributors.')
 end

--- a/app/views/projects/show.json.jbuilder
+++ b/app/views/projects/show.json.jbuilder
@@ -1,1 +1,8 @@
 json.merge! @project.attributes
+if @project.show_entry_license?
+  json.project_entry_license 'CC-BY-3.0+'
+  json.project_entry_attribution ('Please credit '.html_safe +
+                                  @project.user.name +
+                                  ' and the CII Best Practices badge' +
+                                  ' contributors.')
+end


### PR DESCRIPTION
Clearly indicate that all badge entries from now on are CC-BY-3.0+.
Copyright would probably be limited on badge entry data anyway,
but we want to encourage people to see and use this data, so having
a clear common license for the badge entry data is helpful.
We could have chosen CC0 (essentially public domain), which would be
easier for later users because no attribution would be needed.
However, attribution might encourage people to provide data
(and incentivize them to enter *correct* data).
All other non-code information in the badge project is also CC-BY-3.0+,
so this is consistent.

We only indicate this license if there's an updated_at after a date;
this is so the license is only shown if the user has accepted it
(as indicated selecting save or submit just under text declaring this).
We can't just relicense other people's data without their permission;
this seemed like the simplest way to deal with that.
We could go require more ceremony (by requiring a checked checkbox),
but we're trying to maximize ease-of-use here,
and this is essentially the same way that Wikipedia accepts changes,

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>