### PR TITLE
Matt boot strap rows in rows fix

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-xs-12 col-sm-12 col-md-7">
+      <div class="col-xs-12 col-md-7">
         <small>
 <b>Need help? Have a question? See a problem? Please
 <i><a href="mailto:&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;">send an email</a> </i>or
@@ -12,7 +12,7 @@ Please see our
 <a href="https://www.linuxfoundation.org/terms" target="_blank">terms of use</a>.
 </small>
       </div>
-    <div class="col-xs-12 col-sm-12 col-md-5">
+    <div class="col-xs-12 col-md-5">
       <nav>
         <ul>
           <li><%= link_to image_tag('cii-footer.png', {width: 120, height: 30}),'https://www.coreinfrastructure.org/' %></li>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -74,7 +74,7 @@ There is also a
 <%# End column started outside. %>
 </div>
 
-<div class="col-md-3 col-sm-3">
+<div class="col-sm-3">
 </div>
 <%# end row started outside %>
 </div>

--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -10,7 +10,7 @@
       <% crypto_class = is_crypto ? ' criterion-is-crypto' : '' %>
 
      <div class="col-md-2 col-sm-3 col-xs-4 criteria-radio<%= crypto_class %>">
-       <div class="row status-chooser">
+       <div class="status-chooser">
        <span class="criterion-name hidden"><%= criterion.to_s %></span>
        <span class="criterion-category hidden"><%= criterion.category %></span>
        <span class="criterion-future hidden"><%= criterion.future? %></span>


### PR DESCRIPTION
BootStrap doesn't like nested rows. This was throwing a ton of errors because it was in the status-chooser. I tested it a number of ways and just removing the row class from this part of the form seems to work.