### PR TITLE
Cache almost entire project entry when showing it (is_disabled==true)

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -4,6 +4,7 @@
       <div id="badge-progress" class="progress-bar progress-bar-success badge-progress" role="progressbar" aria-valuenow="<%= project.badge_percentage %>" aria-valuemin="0" aria-valuemax="100">0%</div>
     </div>
 <% end %>
+<% cache_if is_disabled, project do %>
 <div>
   <span id="project_entry_form"></span>
   <div class="hidden-print">
@@ -293,8 +294,6 @@ databases when reporting vulnerabilities.
           </li>
 
    <%# Note: render() accepts met_suppress: ..., unmet_placeholder:  ... %>
-      <% cache [project, is_disabled, @result] do %>
-
           <li class="list-group-item"><h3>Basic Project Website Content</h3>
             <%= render_status 'description_good', f, project, is_disabled %>
 
@@ -839,6 +838,6 @@ Please use <a href="https://spdx.org/licenses/">SPDX license expression format</
       </div>
     <% end %>
   </div>
-  <% end %>
 </div>
 </div>
+<% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -293,6 +293,7 @@ databases when reporting vulnerabilities.
           </li>
 
    <%# Note: render() accepts met_suppress: ..., unmet_placeholder:  ... %>
+      <% cache [project, is_disabled, @result] do %>
 
           <li class="list-group-item"><h3>Basic Project Website Content</h3>
             <%= render_status 'description_good', f, project, is_disabled %>
@@ -838,5 +839,6 @@ Please use <a href="https://spdx.org/licenses/">SPDX license expression format</
       </div>
     <% end %>
   </div>
+  <% end %>
 </div>
 </div>


### PR DESCRIPTION
    Cache almost the entire project entry when showing it.
    We don't cache the entry on edit, because it's about to change
    (and is thus pointless).
    
    Local testing shows an 80% increase in speed in the server-side
    completion time when displaying project entries for read (after the
    first display).
    
    We could cache smaller fragments of the project entry for editing,
    but it's not clear it's worth it (at this time).
    
    Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>
