### PR TITLE
Add UI for changing additional rights. Fixes #91

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -123,6 +123,33 @@ class ProjectsController < ApplicationController
   end
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
+  # Forceably set additional rights given string description
+  def update_additional_rights_forced(new_additional_rights)
+    # Delete the current set, then write a new set.
+    AdditionalRight.where(project_id: @project.id).delete_all
+    new_list = new_additional_rights[1..-1].split(',').map(&:to_i).uniq.sort
+    new_list.each do |u|
+      if User.exists?(id: u)
+        AdditionalRight.create!(project_id: @project.id, user_id: u).save!
+      end
+    end
+  end
+
+  VALID_ADD_RIGHTS = /\A=(\d+(,\d+)*)?\z/
+
+  # Set additional rights to params[:additional_rights], if desired
+  # and it's a valid request.  We ignore requests if user can't control.
+  def update_additional_rights
+    return unless can_control?
+    return unless params.key?(:project)
+    new_additional_rights = params[:project][:additional_rights]
+    return if new_additional_rights.blank?
+    return if new_additional_rights[0] != '='
+    new_additional_rights = new_additional_rights.delete(' ')
+    return unless VALID_ADD_RIGHTS.match(new_additional_rights)
+    update_additional_rights_forced(new_additional_rights)
+  end
+
   # PATCH/PUT /projects/1
   # PATCH/PUT /projects/1.json
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -132,6 +159,7 @@ class ProjectsController < ApplicationController
       project_params.each do |key, user_value| # mass assign
         @project[key] = user_value
       end
+      update_additional_rights
       Chief.new(@project, client_factory).autofill
       respond_to do |format|
         # Was project.update(project_params)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -135,6 +135,11 @@ class ProjectsController < ApplicationController
     end
   end
 
+  # "Additional rights" are only considered when they match this pattern.
+  # A leading "=" is required to make change.  This prevents accidental
+  # changes, and also eliminates the need to consult the additional rights
+  # table when updating a project where the rights aren't changing
+  # (the normal case).
   VALID_ADD_RIGHTS = /\A=(\d+(,\d+)*)?\z/
 
   # Set additional rights to params[:additional_rights], if desired

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -174,6 +174,17 @@ class Project < ApplicationRecord
     end
   end
 
+  # Return a string representing the additional rights on this project.
+  # Currently it's just a (possibly empty) list of user ids from
+  # AdditionalRight.  If AdditionalRights gains different kinds of rights
+  # (e.g., to spec additional owners), this method will need to be tweaked.
+  def additional_rights
+    # "distinct" shouldn't be needed; it's purely defensive here
+    list = AdditionalRight.where(project_id: id).distinct.pluck(:user_id)
+    return '' if list.empty?
+    list.sort.to_s[1..-2] # Remove surrounding [ and ]
+  end
+
   # Return string representing badge level; assumes badge_percentage correct.
   def badge_level
     BADGE_LEVELS.each_with_index do |level, index|

--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -291,6 +291,23 @@
       </div>
       </div>
 
+      <div class="row">
+      <div class="col-xs-12">
+        <%= t 'projects.form_basics.additional_rights.description' %>
+        <%= render(partial: "details", locals: {
+          criterion: "additional_rights",
+          details:
+            t('projects.form_basics.additional_rights.details_html') }) %>
+        <%= f.text_field :additional_rights,
+                           hide_label: true, class:"form-control",
+                           placeholder:
+                             t('projects.form_basics.' +
+                               'additional_rights.placeholder'),
+                           spellcheck: false,
+                           disabled: is_disabled %>
+      </div>
+      </div>
+
       <br><br>
       <%= t('projects.misc.general_comments.description') %><br>
       <% if is_disabled %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,6 +425,24 @@ en:
           "BSD-2-Clause", "BSD-3-Clause", "GPL-2.0+", "LGPL-3.0+",
           "MIT", and "(BSD-2-Clause OR Ruby)".
         placeholder: FLOSS License
+      additional_rights:
+        description: >
+          (Advanced) What users have additional
+          rights to edit this badge entry?
+        details_html: >
+          Most projects will want this blank.
+          Project badge entries can be edited by the owner (creator),
+          BadgeApp administrators, and anyone who can commit to the GitHub
+          repository (if it's on GitHub).  If you want someone else to be
+          able to edit this badge entry, modify this field to begin with
+          "=", followed by a comma-separated list of integer user ids.
+          Those users will also be allowed to edit this project entry.
+          This application uses optimistic locking
+          to prevent saving stale data if multiple users
+          try to edit simultaneously.
+          Only owners of this project entry and BadgeApp administrators
+          can change this field.
+        placeholder: User list (usually blank)
     misc:
       in_javascript:
         collapse_all_title: Collapse all panels

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -32,6 +32,7 @@ RemoveUnusedMethodsInModelsCheck: { except_methods: [
   'Criteria#suggested?', # Used in ERB template; doesn't notice.
   'Project#created_since', # Scope called dynamincally
   'Project#updated_since', # Scope called dynamincally
+  'Project#additional_rights', # Used in ERB template; doesn't notice.
   'Criterion#must?', # Used in ERB template; doesn't notice.
   'User#digest'
   ] }


### PR DESCRIPTION
Add a simple interface for editing additional rights.
This makes it possible to create groups for editing
without GitHub (e.g., for PostgreSQL).

Note that only users who control a project (the owner
or a BadgeApp admin) can change the list of additional users
who can edit a project entry.

The interface requires that changes begin with "=";
this simple confirmation trick should reduce the risk
of accidentally changing it.  Users can set it to an
empty list with a simple "=".  The "details" text
provides more details for those who care.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>