### PR TITLE
Add constraints and belongs_to to additional_rights

### DIFF
--- a/app/models/additional_right.rb
+++ b/app/models/additional_right.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class AdditionalRight < ApplicationRecord
+  # List additional rights of users for a given project.
+  # This is a simple associative table (between project and user).
+  # Currently mere *presence* is what matters; it gives the user edit rights
+  # to that project.  In the future this *could* have 1+ additional fields
+  # identifying the specific additional rights of a user over a project.
+  belongs_to :project
+  belongs_to :user
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,6 +6,12 @@
 
 # rubocop:disable Metrics/ClassLength
 class Project < ApplicationRecord
+  has_many :additional_rights
+  # We could add something like this:
+  # + has_many :users, through: :additional_rights
+  # but we don't, because we don't use the other information about those users.
+  # We only need the user_ids and the additional_rights table has that.
+
   using StringRefinements
   using SymbolRefinements
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
   attr_accessor :remember_token, :activation_token, :reset_token
   before_create :create_activation_digest
 
+  has_many :additional_rights
+
   # This is the minimum password length for *new* passwords. After increasing
   # this, users can log into existing user accounts even if they don't meet
   # this requirement.

--- a/db/migrate/20170607201552_add_foreign_key_additional_rights.rb
+++ b/db/migrate/20170607201552_add_foreign_key_additional_rights.rb
@@ -1,0 +1,22 @@
+class AddForeignKeyAdditionalRights < ActiveRecord::Migration[5.1]
+  def change
+    # Modify the additional_rights table to be much pickier about correct
+    # data, in particular through foreign key constraints.
+    # Many Rails tasks run in parallel, so checks there can be racey.
+    # In contrast, putting constraints in the database itself
+    # prevents violation of those constraints.
+
+    # Normally in Rails we'd use this to add a reference with a foreign key:
+    # # add_reference :uploads, :user, foreign_key: true
+    # or use the alise "belongs_to".
+    # However, we *already* have columns for user_id and project_id,
+    # so we'll just add what we need.
+    add_foreign_key :additional_rights, :users
+    add_foreign_key :additional_rights, :projects
+
+    # Add other (narrower) constraints
+    change_column_null :additional_rights, :user_id, false
+    change_column_null :additional_rights, :project_id, false
+    add_index :additional_rights, [:user_id, :project_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170602145609) do
+ActiveRecord::Schema.define(version: 20170607201552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,11 +18,12 @@ ActiveRecord::Schema.define(version: 20170602145609) do
   enable_extension "pg_stat_statements"
 
   create_table "additional_rights", force: :cascade do |t|
-    t.integer "project_id"
-    t.integer "user_id"
+    t.integer "project_id", null: false
+    t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_additional_rights_on_project_id"
+    t.index ["user_id", "project_id"], name: "index_additional_rights_on_user_id_and_project_id", unique: true
     t.index ["user_id"], name: "index_additional_rights_on_user_id"
   end
 
@@ -378,5 +379,7 @@ ActiveRecord::Schema.define(version: 20170602145609) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "additional_rights", "projects"
+  add_foreign_key "additional_rights", "users"
   add_foreign_key "projects", "users"
 end


### PR DESCRIPTION
The additional_rights table is an associative table.
Add relevant constraints and conventional Rails declarations.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>