### PR TITLE
Blackhole kk.php robot attacks

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
   # wp-login.php queries are evidences of WordPress brute-force attacks:
   # http://www.inmotionhosting.com/support/edu/wordpress/
   # wp-login-brute-force-attack
+  match 'kk.php', via: :all, to: 'static_pages#error_404'
   match 'wp-login.php', via: :all, to: 'static_pages#error_404'
   match '.well-known/*path', via: :all, to: 'static_pages#error_404'
 


### PR DESCRIPTION
Signed-off-by: Dan Kohn <dan@dankohn.com>

This is a response to New Relic [showing](https://rpm.newrelic.com/accounts/1653316/applications/48884059/filterable_errors?tw%5Bdur%5D=last_30_minutes&tw%5Bend%5D=1496925078#/show/999ac4f2-4c44-11e7-a209-0242ac110010_0_12288/stack_trace?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart&_k=9orgy9) >5% error rates this morning at the URL `/kk.php` with:
```bash
I18n::InvalidLocale: "kk" is not a valid locale
         /app/app/controllers/application_controller.rb:   75:in `set_locale'
```