### PR TITLE
Modify many database fields to be "not null"

### DIFF
--- a/db/migrate/20170608192851_make_many_not_null.rb
+++ b/db/migrate/20170608192851_make_many_not_null.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+# Modify many database fields to be "not null", that is, they
+# MUST have a value.  This prevents some data problems.
+# This uses:
+# - change_column_null :table_name, :column_name, false
+# where 'false' means 'is null allowed? false.'
+# For unknown status values we use '?' and set it as the default.
+# That way, the value displayed to the user in English
+# is exactly the same as what we store.
+class MakeManyNotNull < ActiveRecord::Migration[5.1]
+  def change
+    # users
+    change_column_null :users, :provider, false
+    # projects
+    change_column_null :projects, :homepage_url_status, false
+    change_column_null :projects, :sites_https_status, false
+    change_column_null :projects, :description_good_status, false
+    change_column_null :projects, :interact_status, false
+    change_column_null :projects, :contribution_status, false
+    change_column_null :projects, :contribution_requirements_status, false
+    change_column_null :projects, :license_location_status, false
+    change_column_null :projects, :floss_license_status, false
+    change_column_null :projects, :floss_license_osi_status, false
+    change_column_null :projects, :documentation_basics_status, false
+    change_column_null :projects, :documentation_interface_status, false
+    change_column_null :projects, :repo_public_status, false
+    change_column_null :projects, :repo_track_status, false
+    change_column_null :projects, :repo_interim_status, false
+    change_column_null :projects, :repo_distributed_status, false
+    change_column_null :projects, :version_unique_status, false
+    change_column_null :projects, :version_semver_status, false
+    change_column_null :projects, :version_tags_status, false
+    change_column_null :projects, :release_notes_status, false
+    change_column_null :projects, :release_notes_vulns_status, false
+    change_column_null :projects, :report_url_status, false
+    change_column_null :projects, :report_tracker_status, false
+    change_column_null :projects, :report_process_status, false
+    change_column_null :projects, :report_responses_status, false
+    change_column_null :projects, :enhancement_responses_status, false
+    change_column_null :projects, :report_archive_status, false
+    change_column_null :projects, :vulnerability_report_process_status, false
+    change_column_null :projects, :vulnerability_report_private_status, false
+    change_column_null :projects, :vulnerability_report_response_status, false
+    change_column_null :projects, :build_status, false
+    change_column_null :projects, :build_common_tools_status, false
+    change_column_null :projects, :build_floss_tools_status, false
+    change_column_null :projects, :test_status, false
+    change_column_null :projects, :test_invocation_status, false
+    change_column_null :projects, :test_most_status, false
+    change_column_null :projects, :test_policy_status, false
+    change_column_null :projects, :tests_are_added_status, false
+    change_column_null :projects, :tests_documented_added_status, false
+    change_column_null :projects, :warnings_status, false
+    change_column_null :projects, :warnings_fixed_status, false
+    change_column_null :projects, :warnings_strict_status, false
+    change_column_null :projects, :know_secure_design_status, false
+    change_column_null :projects, :know_common_errors_status, false
+    change_column_null :projects, :crypto_published_status, false
+    change_column_null :projects, :crypto_call_status, false
+    change_column_null :projects, :crypto_floss_status, false
+    change_column_null :projects, :crypto_keylength_status, false
+    change_column_null :projects, :crypto_working_status, false
+    change_column_null :projects, :crypto_pfs_status, false
+    change_column_null :projects, :crypto_password_storage_status, false
+    change_column_null :projects, :crypto_random_status, false
+    change_column_null :projects, :delivery_mitm_status, false
+    change_column_null :projects, :delivery_unsigned_status, false
+    change_column_null :projects, :vulnerabilities_fixed_60_days_status, false
+    change_column_null :projects, :vulnerabilities_critical_fixed_status, false
+    change_column_null :projects, :static_analysis_status, false
+    change_column_null :projects,
+                       :static_analysis_common_vulnerabilities_status, false
+    change_column_null :projects, :static_analysis_fixed_status, false
+    change_column_null :projects, :static_analysis_often_status, false
+    change_column_null :projects, :dynamic_analysis_status, false
+    change_column_null :projects, :dynamic_analysis_unsafe_status, false
+    change_column_null :projects,
+                       :dynamic_analysis_enable_assertions_status, false
+    change_column_null :projects, :dynamic_analysis_fixed_status, false
+    change_column_null :projects, :crypto_weaknesses_status, false
+    change_column_null :projects, :test_continuous_integration_status, false
+    change_column_null :projects, :discussion_status, false
+    change_column_null :projects, :no_leaked_credentials_status, false
+    change_column_null :projects, :english_status, false
+    change_column_null :projects, :hardening_status, false
+    change_column_null :projects, :crypto_used_network_status, false
+    change_column_null :projects, :crypto_tls12_status, false
+    change_column_null :projects, :crypto_certificate_verification_status, false
+    change_column_null :projects, :crypto_verification_private_status, false
+    change_column_null :projects, :hardened_site_status, false
+    change_column_null :projects, :installation_common_status, false
+    change_column_null :projects, :build_reproducible_status, false
+    change_column_null :projects, :dco_status, false
+    change_column_null :projects, :governance_status, false
+    change_column_null :projects, :code_of_conduct_status, false
+    change_column_null :projects, :roles_responsibilities_status, false
+    change_column_null :projects, :access_continuity_status, false
+    change_column_null :projects, :bus_factor_status, false
+    change_column_null :projects, :documentation_roadmap_status, false
+    change_column_null :projects, :documentation_architecture_status, false
+    change_column_null :projects, :documentation_security_status, false
+    change_column_null :projects, :documentation_quick_start_status, false
+    change_column_null :projects, :documentation_current_status, false
+    change_column_null :projects, :documentation_achievements_status, false
+    change_column_null :projects, :accessibility_best_practices_status, false
+    change_column_null :projects, :internationalization_status, false
+    change_column_null :projects, :sites_password_security_status, false
+    change_column_null :projects, :maintenance_or_update_status, false
+    change_column_null :projects, :vulnerability_report_credit_status, false
+    change_column_null :projects, :vulnerability_response_process_status, false
+    change_column_null :projects, :coding_standards_status, false
+    change_column_null :projects, :coding_standards_enforced_status, false
+    change_column_null :projects, :build_standard_variables_status, false
+    change_column_null :projects, :build_preserve_debug_status, false
+    change_column_null :projects, :build_non_recursive_status, false
+    change_column_null :projects, :build_repeatable_status, false
+    change_column_null :projects, :installation_standard_variables_status, false
+    change_column_null :projects, :installation_development_quick_status, false
+    change_column_null :projects, :external_dependencies_status, false
+    change_column_null :projects, :dependency_monitoring_status, false
+    change_column_null :projects, :updateable_reused_components_status, false
+    change_column_null :projects, :interfaces_current_status, false
+    change_column_null :projects, :automated_integration_testing_status, false
+    change_column_null :projects, :regression_tests_added50_status, false
+    change_column_null :projects, :test_statement_coverage80_status, false
+    change_column_null :projects, :test_policy_mandated_status, false
+    change_column_null :projects, :implement_secure_design_status, false
+    change_column_null :projects, :input_validation_status, false
+    change_column_null :projects, :crypto_algorithm_agility_status, false
+    change_column_null :projects, :crypto_credential_agility_status, false
+    change_column_null :projects, :signed_releases_status, false
+    change_column_null :projects, :version_tags_signed_status, false
+    change_column_null :projects, :contributors_unassociated_status, false
+    change_column_null :projects, :copyright_per_file_status, false
+    change_column_null :projects, :license_per_file_status, false
+    change_column_null :projects, :small_tasks_status, false
+    change_column_null :projects, :require_2FA_status, false
+    change_column_null :projects, :secure_2FA_status, false
+    change_column_null :projects, :code_review_standards_status, false
+    change_column_null :projects, :two_person_review_status, false
+    change_column_null :projects, :test_statement_coverage90_status, false
+    change_column_null :projects, :test_branch_coverage80_status, false
+    change_column_null :projects, :security_review_status, false
+    change_column_null :projects, :assurance_case_status, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170607201552) do
+ActiveRecord::Schema.define(version: 20170608192851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,161 +64,161 @@ ActiveRecord::Schema.define(version: 20170607201552) do
     t.string "homepage_url"
     t.string "repo_url"
     t.string "license"
-    t.string "homepage_url_status", default: "?"
+    t.string "homepage_url_status", default: "?", null: false
     t.text "homepage_url_justification"
-    t.string "sites_https_status", default: "?"
+    t.string "sites_https_status", default: "?", null: false
     t.text "sites_https_justification"
-    t.string "description_good_status", default: "?"
+    t.string "description_good_status", default: "?", null: false
     t.text "description_good_justification"
-    t.string "interact_status", default: "?"
+    t.string "interact_status", default: "?", null: false
     t.text "interact_justification"
-    t.string "contribution_status", default: "?"
+    t.string "contribution_status", default: "?", null: false
     t.text "contribution_justification"
-    t.string "contribution_requirements_status", default: "?"
+    t.string "contribution_requirements_status", default: "?", null: false
     t.text "contribution_requirements_justification"
-    t.string "license_location_status", default: "?"
+    t.string "license_location_status", default: "?", null: false
     t.text "license_location_justification"
-    t.string "floss_license_status", default: "?"
+    t.string "floss_license_status", default: "?", null: false
     t.text "floss_license_justification"
-    t.string "floss_license_osi_status", default: "?"
+    t.string "floss_license_osi_status", default: "?", null: false
     t.text "floss_license_osi_justification"
-    t.string "documentation_basics_status", default: "?"
+    t.string "documentation_basics_status", default: "?", null: false
     t.text "documentation_basics_justification"
-    t.string "documentation_interface_status", default: "?"
+    t.string "documentation_interface_status", default: "?", null: false
     t.text "documentation_interface_justification"
-    t.string "repo_public_status", default: "?"
+    t.string "repo_public_status", default: "?", null: false
     t.text "repo_public_justification"
-    t.string "repo_track_status", default: "?"
+    t.string "repo_track_status", default: "?", null: false
     t.text "repo_track_justification"
-    t.string "repo_interim_status", default: "?"
+    t.string "repo_interim_status", default: "?", null: false
     t.text "repo_interim_justification"
-    t.string "repo_distributed_status", default: "?"
+    t.string "repo_distributed_status", default: "?", null: false
     t.text "repo_distributed_justification"
-    t.string "version_unique_status", default: "?"
+    t.string "version_unique_status", default: "?", null: false
     t.text "version_unique_justification"
-    t.string "version_semver_status", default: "?"
+    t.string "version_semver_status", default: "?", null: false
     t.text "version_semver_justification"
-    t.string "version_tags_status", default: "?"
+    t.string "version_tags_status", default: "?", null: false
     t.text "version_tags_justification"
-    t.string "release_notes_status", default: "?"
+    t.string "release_notes_status", default: "?", null: false
     t.text "release_notes_justification"
-    t.string "release_notes_vulns_status", default: "?"
+    t.string "release_notes_vulns_status", default: "?", null: false
     t.text "release_notes_vulns_justification"
-    t.string "report_url_status", default: "?"
+    t.string "report_url_status", default: "?", null: false
     t.text "report_url_justification"
-    t.string "report_tracker_status", default: "?"
+    t.string "report_tracker_status", default: "?", null: false
     t.text "report_tracker_justification"
-    t.string "report_process_status", default: "?"
+    t.string "report_process_status", default: "?", null: false
     t.text "report_process_justification"
-    t.string "report_responses_status", default: "?"
+    t.string "report_responses_status", default: "?", null: false
     t.text "report_responses_justification"
-    t.string "enhancement_responses_status", default: "?"
+    t.string "enhancement_responses_status", default: "?", null: false
     t.text "enhancement_responses_justification"
-    t.string "report_archive_status", default: "?"
+    t.string "report_archive_status", default: "?", null: false
     t.text "report_archive_justification"
-    t.string "vulnerability_report_process_status", default: "?"
+    t.string "vulnerability_report_process_status", default: "?", null: false
     t.text "vulnerability_report_process_justification"
-    t.string "vulnerability_report_private_status", default: "?"
+    t.string "vulnerability_report_private_status", default: "?", null: false
     t.text "vulnerability_report_private_justification"
-    t.string "vulnerability_report_response_status", default: "?"
+    t.string "vulnerability_report_response_status", default: "?", null: false
     t.text "vulnerability_report_response_justification"
-    t.string "build_status", default: "?"
+    t.string "build_status", default: "?", null: false
     t.text "build_justification"
-    t.string "build_common_tools_status", default: "?"
+    t.string "build_common_tools_status", default: "?", null: false
     t.text "build_common_tools_justification"
-    t.string "build_floss_tools_status", default: "?"
+    t.string "build_floss_tools_status", default: "?", null: false
     t.text "build_floss_tools_justification"
-    t.string "test_status", default: "?"
+    t.string "test_status", default: "?", null: false
     t.text "test_justification"
-    t.string "test_invocation_status", default: "?"
+    t.string "test_invocation_status", default: "?", null: false
     t.text "test_invocation_justification"
-    t.string "test_most_status", default: "?"
+    t.string "test_most_status", default: "?", null: false
     t.text "test_most_justification"
-    t.string "test_policy_status", default: "?"
+    t.string "test_policy_status", default: "?", null: false
     t.text "test_policy_justification"
-    t.string "tests_are_added_status", default: "?"
+    t.string "tests_are_added_status", default: "?", null: false
     t.text "tests_are_added_justification"
-    t.string "tests_documented_added_status", default: "?"
+    t.string "tests_documented_added_status", default: "?", null: false
     t.text "tests_documented_added_justification"
-    t.string "warnings_status", default: "?"
+    t.string "warnings_status", default: "?", null: false
     t.text "warnings_justification"
-    t.string "warnings_fixed_status", default: "?"
+    t.string "warnings_fixed_status", default: "?", null: false
     t.text "warnings_fixed_justification"
-    t.string "warnings_strict_status", default: "?"
+    t.string "warnings_strict_status", default: "?", null: false
     t.text "warnings_strict_justification"
-    t.string "know_secure_design_status", default: "?"
+    t.string "know_secure_design_status", default: "?", null: false
     t.text "know_secure_design_justification"
-    t.string "know_common_errors_status", default: "?"
+    t.string "know_common_errors_status", default: "?", null: false
     t.text "know_common_errors_justification"
-    t.string "crypto_published_status", default: "?"
+    t.string "crypto_published_status", default: "?", null: false
     t.text "crypto_published_justification"
-    t.string "crypto_call_status", default: "?"
+    t.string "crypto_call_status", default: "?", null: false
     t.text "crypto_call_justification"
-    t.string "crypto_floss_status", default: "?"
+    t.string "crypto_floss_status", default: "?", null: false
     t.text "crypto_floss_justification"
-    t.string "crypto_keylength_status", default: "?"
+    t.string "crypto_keylength_status", default: "?", null: false
     t.text "crypto_keylength_justification"
-    t.string "crypto_working_status", default: "?"
+    t.string "crypto_working_status", default: "?", null: false
     t.text "crypto_working_justification"
-    t.string "crypto_pfs_status", default: "?"
+    t.string "crypto_pfs_status", default: "?", null: false
     t.text "crypto_pfs_justification"
-    t.string "crypto_password_storage_status", default: "?"
+    t.string "crypto_password_storage_status", default: "?", null: false
     t.text "crypto_password_storage_justification"
-    t.string "crypto_random_status", default: "?"
+    t.string "crypto_random_status", default: "?", null: false
     t.text "crypto_random_justification"
-    t.string "delivery_mitm_status", default: "?"
+    t.string "delivery_mitm_status", default: "?", null: false
     t.text "delivery_mitm_justification"
-    t.string "delivery_unsigned_status", default: "?"
+    t.string "delivery_unsigned_status", default: "?", null: false
     t.text "delivery_unsigned_justification"
-    t.string "vulnerabilities_fixed_60_days_status", default: "?"
+    t.string "vulnerabilities_fixed_60_days_status", default: "?", null: false
     t.text "vulnerabilities_fixed_60_days_justification"
-    t.string "vulnerabilities_critical_fixed_status", default: "?"
+    t.string "vulnerabilities_critical_fixed_status", default: "?", null: false
     t.text "vulnerabilities_critical_fixed_justification"
-    t.string "static_analysis_status", default: "?"
+    t.string "static_analysis_status", default: "?", null: false
     t.text "static_analysis_justification"
-    t.string "static_analysis_common_vulnerabilities_status", default: "?"
+    t.string "static_analysis_common_vulnerabilities_status", default: "?", null: false
     t.text "static_analysis_common_vulnerabilities_justification"
-    t.string "static_analysis_fixed_status", default: "?"
+    t.string "static_analysis_fixed_status", default: "?", null: false
     t.text "static_analysis_fixed_justification"
-    t.string "static_analysis_often_status", default: "?"
+    t.string "static_analysis_often_status", default: "?", null: false
     t.text "static_analysis_often_justification"
-    t.string "dynamic_analysis_status", default: "?"
+    t.string "dynamic_analysis_status", default: "?", null: false
     t.text "dynamic_analysis_justification"
-    t.string "dynamic_analysis_unsafe_status", default: "?"
+    t.string "dynamic_analysis_unsafe_status", default: "?", null: false
     t.text "dynamic_analysis_unsafe_justification"
-    t.string "dynamic_analysis_enable_assertions_status", default: "?"
+    t.string "dynamic_analysis_enable_assertions_status", default: "?", null: false
     t.text "dynamic_analysis_enable_assertions_justification"
-    t.string "dynamic_analysis_fixed_status", default: "?"
+    t.string "dynamic_analysis_fixed_status", default: "?", null: false
     t.text "dynamic_analysis_fixed_justification"
     t.text "general_comments"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "crypto_weaknesses_status", default: "?"
+    t.string "crypto_weaknesses_status", default: "?", null: false
     t.text "crypto_weaknesses_justification"
-    t.string "test_continuous_integration_status", default: "?"
+    t.string "test_continuous_integration_status", default: "?", null: false
     t.text "test_continuous_integration_justification"
     t.string "cpe"
-    t.string "discussion_status", default: "?"
+    t.string "discussion_status", default: "?", null: false
     t.text "discussion_justification"
-    t.string "no_leaked_credentials_status", default: "?"
+    t.string "no_leaked_credentials_status", default: "?", null: false
     t.text "no_leaked_credentials_justification"
-    t.string "english_status", default: "?"
+    t.string "english_status", default: "?", null: false
     t.text "english_justification"
-    t.string "hardening_status", default: "?"
+    t.string "hardening_status", default: "?", null: false
     t.text "hardening_justification"
-    t.string "crypto_used_network_status", default: "?"
+    t.string "crypto_used_network_status", default: "?", null: false
     t.text "crypto_used_network_justification"
-    t.string "crypto_tls12_status", default: "?"
+    t.string "crypto_tls12_status", default: "?", null: false
     t.text "crypto_tls12_justification"
-    t.string "crypto_certificate_verification_status", default: "?"
+    t.string "crypto_certificate_verification_status", default: "?", null: false
     t.text "crypto_certificate_verification_justification"
-    t.string "crypto_verification_private_status", default: "?"
+    t.string "crypto_verification_private_status", default: "?", null: false
     t.text "crypto_verification_private_justification"
-    t.string "hardened_site_status", default: "?"
+    t.string "hardened_site_status", default: "?", null: false
     t.text "hardened_site_justification"
-    t.string "installation_common_status", default: "?"
+    t.string "installation_common_status", default: "?", null: false
     t.text "installation_common_justification"
-    t.string "build_reproducible_status", default: "?"
+    t.string "build_reproducible_status", default: "?", null: false
     t.text "build_reproducible_justification"
     t.integer "badge_percentage_0"
     t.datetime "achieved_passing_at"
@@ -228,110 +228,110 @@ ActiveRecord::Schema.define(version: 20170607201552) do
     t.string "implementation_languages", default: ""
     t.integer "lock_version", default: 0
     t.integer "badge_percentage_1", default: 0
-    t.string "dco_status", default: "?"
+    t.string "dco_status", default: "?", null: false
     t.text "dco_justification"
-    t.string "governance_status", default: "?"
+    t.string "governance_status", default: "?", null: false
     t.text "governance_justification"
-    t.string "code_of_conduct_status", default: "?"
+    t.string "code_of_conduct_status", default: "?", null: false
     t.text "code_of_conduct_justification"
-    t.string "roles_responsibilities_status", default: "?"
+    t.string "roles_responsibilities_status", default: "?", null: false
     t.text "roles_responsibilities_justification"
-    t.string "access_continuity_status", default: "?"
+    t.string "access_continuity_status", default: "?", null: false
     t.text "access_continuity_justification"
-    t.string "bus_factor_status", default: "?"
+    t.string "bus_factor_status", default: "?", null: false
     t.text "bus_factor_justification"
-    t.string "documentation_roadmap_status", default: "?"
+    t.string "documentation_roadmap_status", default: "?", null: false
     t.text "documentation_roadmap_justification"
-    t.string "documentation_architecture_status", default: "?"
+    t.string "documentation_architecture_status", default: "?", null: false
     t.text "documentation_architecture_justification"
-    t.string "documentation_security_status", default: "?"
+    t.string "documentation_security_status", default: "?", null: false
     t.text "documentation_security_justification"
-    t.string "documentation_quick_start_status", default: "?"
+    t.string "documentation_quick_start_status", default: "?", null: false
     t.text "documentation_quick_start_justification"
-    t.string "documentation_current_status", default: "?"
+    t.string "documentation_current_status", default: "?", null: false
     t.text "documentation_current_justification"
-    t.string "documentation_achievements_status", default: "?"
+    t.string "documentation_achievements_status", default: "?", null: false
     t.text "documentation_achievements_justification"
-    t.string "accessibility_best_practices_status", default: "?"
+    t.string "accessibility_best_practices_status", default: "?", null: false
     t.text "accessibility_best_practices_justification"
-    t.string "internationalization_status", default: "?"
+    t.string "internationalization_status", default: "?", null: false
     t.text "internationalization_justification"
-    t.string "sites_password_security_status", default: "?"
+    t.string "sites_password_security_status", default: "?", null: false
     t.text "sites_password_security_justification"
-    t.string "maintenance_or_update_status", default: "?"
+    t.string "maintenance_or_update_status", default: "?", null: false
     t.text "maintenance_or_update_justification"
-    t.string "vulnerability_report_credit_status", default: "?"
+    t.string "vulnerability_report_credit_status", default: "?", null: false
     t.text "vulnerability_report_credit_justification"
-    t.string "vulnerability_response_process_status", default: "?"
+    t.string "vulnerability_response_process_status", default: "?", null: false
     t.text "vulnerability_response_process_justification"
-    t.string "coding_standards_status", default: "?"
+    t.string "coding_standards_status", default: "?", null: false
     t.text "coding_standards_justification"
-    t.string "coding_standards_enforced_status", default: "?"
+    t.string "coding_standards_enforced_status", default: "?", null: false
     t.text "coding_standards_enforced_justification"
-    t.string "build_standard_variables_status", default: "?"
+    t.string "build_standard_variables_status", default: "?", null: false
     t.text "build_standard_variables_justification"
-    t.string "build_preserve_debug_status", default: "?"
+    t.string "build_preserve_debug_status", default: "?", null: false
     t.text "build_preserve_debug_justification"
-    t.string "build_non_recursive_status", default: "?"
+    t.string "build_non_recursive_status", default: "?", null: false
     t.text "build_non_recursive_justification"
-    t.string "build_repeatable_status", default: "?"
+    t.string "build_repeatable_status", default: "?", null: false
     t.text "build_repeatable_justification"
-    t.string "installation_standard_variables_status", default: "?"
+    t.string "installation_standard_variables_status", default: "?", null: false
     t.text "installation_standard_variables_justification"
-    t.string "installation_development_quick_status", default: "?"
+    t.string "installation_development_quick_status", default: "?", null: false
     t.text "installation_development_quick_justification"
-    t.string "external_dependencies_status", default: "?"
+    t.string "external_dependencies_status", default: "?", null: false
     t.text "external_dependencies_justification"
-    t.string "dependency_monitoring_status", default: "?"
+    t.string "dependency_monitoring_status", default: "?", null: false
     t.text "dependency_monitoring_justification"
-    t.string "updateable_reused_components_status", default: "?"
+    t.string "updateable_reused_components_status", default: "?", null: false
     t.text "updateable_reused_components_justification"
-    t.string "interfaces_current_status", default: "?"
+    t.string "interfaces_current_status", default: "?", null: false
     t.text "interfaces_current_justification"
-    t.string "automated_integration_testing_status", default: "?"
+    t.string "automated_integration_testing_status", default: "?", null: false
     t.text "automated_integration_testing_justification"
-    t.string "regression_tests_added50_status", default: "?"
+    t.string "regression_tests_added50_status", default: "?", null: false
     t.text "regression_tests_added50_justification"
-    t.string "test_statement_coverage80_status", default: "?"
+    t.string "test_statement_coverage80_status", default: "?", null: false
     t.text "test_statement_coverage80_justification"
-    t.string "test_policy_mandated_status", default: "?"
+    t.string "test_policy_mandated_status", default: "?", null: false
     t.text "test_policy_mandated_justification"
-    t.string "implement_secure_design_status", default: "?"
+    t.string "implement_secure_design_status", default: "?", null: false
     t.text "implement_secure_design_justification"
-    t.string "input_validation_status", default: "?"
+    t.string "input_validation_status", default: "?", null: false
     t.text "input_validation_justification"
-    t.string "crypto_algorithm_agility_status", default: "?"
+    t.string "crypto_algorithm_agility_status", default: "?", null: false
     t.text "crypto_algorithm_agility_justification"
-    t.string "crypto_credential_agility_status", default: "?"
+    t.string "crypto_credential_agility_status", default: "?", null: false
     t.text "crypto_credential_agility_justification"
-    t.string "signed_releases_status", default: "?"
+    t.string "signed_releases_status", default: "?", null: false
     t.text "signed_releases_justification"
-    t.string "version_tags_signed_status", default: "?"
+    t.string "version_tags_signed_status", default: "?", null: false
     t.text "version_tags_signed_justification"
     t.integer "badge_percentage_2", default: 0
-    t.string "contributors_unassociated_status", default: "?"
+    t.string "contributors_unassociated_status", default: "?", null: false
     t.text "contributors_unassociated_justification"
-    t.string "copyright_per_file_status", default: "?"
+    t.string "copyright_per_file_status", default: "?", null: false
     t.text "copyright_per_file_justification"
-    t.string "license_per_file_status", default: "?"
+    t.string "license_per_file_status", default: "?", null: false
     t.text "license_per_file_justification"
-    t.string "small_tasks_status", default: "?"
+    t.string "small_tasks_status", default: "?", null: false
     t.text "small_tasks_justification"
-    t.string "require_2FA_status", default: "?"
+    t.string "require_2FA_status", default: "?", null: false
     t.text "require_2FA_justification"
-    t.string "secure_2FA_status", default: "?"
+    t.string "secure_2FA_status", default: "?", null: false
     t.text "secure_2FA_justification"
-    t.string "code_review_standards_status", default: "?"
+    t.string "code_review_standards_status", default: "?", null: false
     t.text "code_review_standards_justification"
-    t.string "two_person_review_status", default: "?"
+    t.string "two_person_review_status", default: "?", null: false
     t.text "two_person_review_justification"
-    t.string "test_statement_coverage90_status", default: "?"
+    t.string "test_statement_coverage90_status", default: "?", null: false
     t.text "test_statement_coverage90_justification"
-    t.string "test_branch_coverage80_status", default: "?"
+    t.string "test_branch_coverage80_status", default: "?", null: false
     t.text "test_branch_coverage80_justification"
-    t.string "security_review_status", default: "?"
+    t.string "security_review_status", default: "?", null: false
     t.text "security_review_justification"
-    t.string "assurance_case_status", default: "?"
+    t.string "assurance_case_status", default: "?", null: false
     t.text "assurance_case_justification"
     t.index ["achieved_passing_at"], name: "index_projects_on_achieved_passing_at"
     t.index ["badge_percentage_0"], name: "index_projects_on_badge_percentage_0"
@@ -347,7 +347,7 @@ ActiveRecord::Schema.define(version: 20170607201552) do
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
-    t.string "provider"
+    t.string "provider", null: false
     t.string "uid"
     t.string "name"
     t.string "nickname"

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -341,7 +341,8 @@ the type of the column, and then various options):
 ~~~~
 class MIGRATION_NAME < ActiveRecord::Migration
   def change
-    add_column :projects, :crypto_alternatives_status, :string, default: '?'
+    add_column :projects, :crypto_alternatives_status, :string,
+               null: false, default: '?'
     add_column :projects, :crypto_alternatives_justification, :text
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,6 +10,7 @@ class UserTest < ActiveSupport::TestCase
   setup do
     @user = User.new(
       name: 'Example User', email: 'user@example.com',
+      provider: 'local',
       password: 'p@$$w0rd', password_confirmation: 'p@$$w0rd'
     )
   end


### PR DESCRIPTION
This prevents some data problems, since even if the application
has a bug, the database will prevent certain invalid values.

For unknown status values we use '?' and set it as the default,
instead of using "null" to indicate unknown values.
That way, the value displayed to the user in English
is exactly the same as what we store.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>