### PR TITLE
Add "OR" on the project creation page as a snippet to translate

### DIFF
--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -30,7 +30,7 @@
                     title: t('.post_delay_warning') %>
      <% end %>
 
-     <br><h2 class='center'>OR</h2>
+     <br><h2 class='center'><%= t('.new_badge_or') %></h2>
   <% end %>
   <br>
   <%= form_for(@project) do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,6 +236,7 @@ en:
       new_badge: New badge
       may_select_html: 'You may select from one of your GitHub repos <em>OR</em> provide
         information about some other project.
+      new_badge_or: OR
 
 '
       select_one_github: Select one of your GitHub repos


### PR DESCRIPTION
This is pure guesswork in terms of syntax. Although OR is a short word, no reason to keep it untranslated, especially since it is in the largest font in the middle of the project creation page.