### PR TITLE
Tentative to internationalize the error messages for wrong forms

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -471,7 +471,7 @@ class Project < ApplicationRecord
 
   def need_a_base_url
     return unless repo_url.blank? && homepage_url.blank?
-    errors.add :base, 'Need at least a home page or repository URL'
+    errors.add :base, error_messages.need_home_page_or_url
   end
 
   def update_passing_times(old_badge_percentage)

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -3,7 +3,7 @@
 <% if object.errors.any? %>
   <div id="error_explanation">
     <div class="alert alert-danger">
-      The form contains <%= pluralize(object.errors.count, "error") %>.
+      <%= t 'error_messages.form_contains', count: object.errors.count %>
     </div>
     <ul>
     <% object.errors.full_messages.each do |msg| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2432,6 +2432,11 @@ en:
     Met: Met
     Unmet: Unmet
     NA: N/A
+  error_messages:
+    need_home_page_or_url: Need at least a home page or repository URL
+    form_contains:
+      one: The form contains 1 error.
+      other: The form contains %{count} errors.
   # Last translation entry, here for test purposes so that we can detect
   # some problems in YAML formatting of this file.
   last_entry: Last translation entry


### PR DESCRIPTION
One thing that this does not fix is the "error/errors", which requires
a different solution that the current one with "pluralize" which works
for English, but would not work in other languages.

Also, I'm not sure at all about the allowed scope/syntax for these named
strings, so the patch might be completely wrong. At least it shows what
I'm trying to do. :-)