### PR TITLE
Only run bootsnap in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem 'will_paginate', '3.1.6' # Paginate results (next/previous)
 
 group :development, :test do
   gem 'awesome_print', '1.7.0'
-  gem 'bootsnap', '1.0.0' # Speed up boot via caches
   gem 'bullet', '5.5.1'
   gem 'bundler-audit', '0.5.0'
   gem 'database_cleaner', '1.6.1' # Cleans up database between tests
@@ -72,6 +71,7 @@ group :fake_production, :development, :test do
 end
 
 group :development do
+  gem 'bootsnap', '1.0.0' # Speed up boot via caches
   # gem 'fasterer', '0.3.2' # Provide speed recommendations - run 'fasterer'
   # Waiting for Ruby 2.4 support: https://github.com/seattlerb/ruby_parser/issues/239
   gem 'traceroute', '0.5.0' # Adds 'rake traceroute' command to check routes

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -8,7 +8,7 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 
-unless ENV['RAILS_ENV'] == 'production'
+if ENV['RAILS_ENV'] == 'development'
   require 'bootsnap'
   Bootsnap.setup(
     # Path to your cache


### PR DESCRIPTION
Bootsnap can speed startup by using caches. However, we can't use it in:

* testing, because it makes test coverage results wrong
* production, because we regenerate things on restart (so it doesn't help)
* fake_production, because we want fake_production to be maximally
  similar to production.

So, use it only in development.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>