### PR TITLE
Default all Rubocops to on

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
-Rails:
-  Enabled: true
 AllCops:
-  TargetRubyVersion: 2.3
+  EnabledByDefault: true
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
   DisplayStyleGuide: true
   Include:
@@ -38,31 +37,19 @@ Metrics/MethodLength:
 Rails/SkipsModelValidations:
   Exclude:
     - 'test/**/*.rb'
-Style/AutoResourceCleanup:
-  Enabled: true
-Style/CollectionMethods:
-  Enabled: true
-Style/Encoding:
-  Enabled: true
-Layout/FirstArrayElementLineBreak:
-  Enabled: true
-Layout/FirstHashElementLineBreak:
-  Enabled: true
-Layout/FirstMethodArgumentLineBreak:
-  Enabled: true
-Layout/FirstMethodParameterLineBreak:
-  Enabled: true
-Layout/MultilineAssignmentLayout:
-  Enabled: true
+Style/Copyright:
+  Enabled: false
+Style/InlineComment:
+  Enabled: false
+Style/DocumentationMethod:
+  Enabled: false
+Style/MethodCallWithArgsParentheses:
+  Enabled: false
+Style/MissingElse:
+  Enabled: false
 Style/NegatedIf:
   Enabled: true
   EnforcedStyle: postfix
-Style/OptionHash:
-  Enabled: true
-Style/StringMethods:
-  Enabled: true
-Style/SymbolArray:
-  Enabled: true
-Style/TrivialAccessors:
-  Enabled: true
-  ExactNameMatch: true
+Style/Send:
+  Exclude:
+    - 'test/**/*.rb'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -170,7 +170,7 @@ class ProjectsController < ApplicationController
   # DELETE /projects/1.json
   # rubocop:disable Metrics/MethodLength
   def destroy
-    @project.destroy
+    @project.destroy!
     ReportMailer.report_project_deleted(@project, current_user).deliver_now
     purge_cdn_project
     # @project.purge
@@ -341,6 +341,7 @@ class ProjectsController < ApplicationController
     end
   end
 
+  # rubocop:disable Style/MethodCalledOnDoEndBlock
   def repo_data
     github = Octokit::Client.new access_token: session[:user_token]
     Octokit.auto_paginate = true
@@ -349,6 +350,7 @@ class ProjectsController < ApplicationController
       [repo.full_name, repo.fork, repo.homepage, repo.html_url]
     end.compact
   end
+  # rubocop:enable Style/MethodCalledOnDoEndBlock
 
   HTML_INDEX_FIELDS = 'projects.id, projects.name, description, ' \
     'homepage_url, repo_url, license, user_id, achieved_passing_at, ' \
@@ -359,7 +361,7 @@ class ProjectsController < ApplicationController
   def retrieve_projects
     @projects = Project.all
     # We had to keep this line the same to satisfy brakeman
-    @projects = @projects.send params[:status] if
+    @projects = @projects.public_send params[:status] if
        %w[in_progress passing].include? params[:status]
     @projects = @projects.gteq(params[:gteq]) if params[:gteq].present?
     @projects = @projects.lteq(params[:lteq]) if params[:lteq].present?
@@ -398,7 +400,7 @@ class ProjectsController < ApplicationController
 
   def set_criteria_level
     @criteria_level = criteria_level_params[:criteria_level] || '0'
-    @criteria_level = '0' unless @criteria_level =~ /\A[0-2]\Z/
+    @criteria_level = '0' unless @criteria_level.match?(/\A[0-2]\Z/)
   end
 
   def set_valid_query_url

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -90,7 +90,7 @@ class UsersController < ApplicationController
       Project.where('user_id = ?', id_to_delete)
              .update_all(user_id: current_user.id)
       # rubocop: enable Rails/SkipsModelValidations
-      user_to_delete.destroy
+      user_to_delete.destroy!
       flash[:success] = t('.user_deleted')
     end
     redirect_to users_url

--- a/app/lib/floss_license_detective.rb
+++ b/app/lib/floss_license_detective.rb
@@ -126,7 +126,7 @@ class FlossLicenseDetective < Detective
                      'Open Source Initiative (OSI).'
           }
       }
-    elsif license =~ /\A[^(]/
+    elsif license.match?(/\A[^(]/)
       { floss_license_osi_status:
           {
             value: 'Unmet', confidence: 1,

--- a/app/lib/subdir_file_contents_detective.rb
+++ b/app/lib/subdir_file_contents_detective.rb
@@ -57,7 +57,7 @@ class SubdirFileContentsDetective < Detective
       patterns[:contents].each do |pattern|
         file_entry = repo_files.get_info(fso['path'])
         content = Base64.decode64(file_entry['content'])
-        return met_result description if content.match(pattern)
+        return met_result description if content.match?(pattern)
       end
     end
     unmet_result description

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -303,7 +303,7 @@ class Project < ApplicationRecord
   # We need this we precalculate and store percentages in the database;
   # this speeds up many actions, but it means that a change in the rules
   # doesn't automatically change the precalculated values.
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Style/MethodCalledOnDoEndBlock
   def self.update_all_badge_percentages
     Project.find_each do |project|
       project.with_lock do
@@ -321,7 +321,7 @@ class Project < ApplicationRecord
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength, Style/MethodCalledOnDoEndBlock
 
   # The following configuration options are trusted.  Set them to
   # reasonable numbers or accept the defaults.

--- a/app/models/project_stat.rb
+++ b/app/models/project_stat.rb
@@ -22,7 +22,7 @@ class ProjectStat < ApplicationRecord
     Project.transaction do
       # Count projects at different levels of completion
       STAT_VALUES.each do |completion|
-        send "percent_ge_#{completion}=", Project.gteq(completion).count
+        public_send "percent_ge_#{completion}=", Project.gteq(completion).count
       end
       self.projects_edited = Project.where('created_at < updated_at').count
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ApplicationRecord
 
   # Returns true if the given token matches the digest
   def authenticated?(attribute, token)
-    digest = send("#{attribute}_digest")
+    digest = public_send("#{attribute}_digest")
     return false if digest.nil?
     BCrypt::Password.new(digest).is_password?(token)
   end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -6,7 +6,7 @@
 
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    return if value.match?(/\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i)
     record.errors.add attribute, (options[:message] ||
       I18n.t('error_messages.not_an_email'))
   end

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -46,7 +46,7 @@ desc 'Ensure that rbenv or rvm are set up in PATH'
 task :rbenv_rvm_setup do
   path = ENV['PATH']
   if !path.include?('.rbenv') && !path.include?('.rvm')
-    raise 'Must have rbenv or rvm in PATH'
+    raise RuntimeError 'Must have rbenv or rvm in PATH'
   end
 end
 
@@ -444,19 +444,23 @@ end
 # that do not have a badge.
 # Configure your system (e.g., Heroku) to run this daily.  If you're using
 # Heroku, see: https://devcenter.heroku.com/articles/scheduler
+# rubocop:disable Style/Send
 desc 'Send reminders to the oldest inactive project badge entries.'
 task reminders: :environment do
   puts 'Sending inactive project reminders. List of reminded project ids:'
   p ProjectsController.send :send_reminders
   true
 end
+# rubocop:enable Style/Send
 
+# rubocop:disable Style/Send
 desc 'Send monthly announcement of passing projects'
 task monthly_announcement: :environment do
   puts 'Sending monthly announcement. List of reminded project ids:'
   p ProjectsController.send :send_monthly_announcement
   true
 end
+# rubocop:enable Style/Send
 
 desc 'Run monthly tasks (called from "daily")'
 task monthly: %i[environment monthly_announcement] do

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -129,7 +129,7 @@ class ProjectsControllerTest < ActionController::TestCase
       user_id: test_user.id,
       project_id: @project.id
     )
-    new_right.save
+    new_right.save!
     log_in_as(test_user)
     get :edit, params: { id: @project }
     assert_response :success


### PR DESCRIPTION
Signed-off-by: Dan Kohn <dan@dankohn.com>

A number of cops are [disabled](https://github.com/bbatsov/rubocop/blob/master/config/disabled.yml) by default. This PR turns on all cops by default and then explicitly disables the ones that are too annoying, such as forbidding inline comments. This both found additional improvements now and will enable new disabled cops by default in future versions.

Note that calling private `send` is appropriate for testing private methods but should not need to be used in regular code.

For posterity, here was the report of all violations that the current .rubocop.yml found:
```bash
Offenses:

app/controllers/projects_controller.rb:173:14: C: Rails/SaveBang: Use destroy! instead of destroy if the return value is not checked. (https://github.com/bbatsov/rails-style-guide#save-bang)
    @project.destroy
             ^^^^^^^
app/controllers/projects_controller.rb:350:5: C: Style/MethodCalledOnDoEndBlock: Avoid chaining a method call on a do...end block. (https://github.com/bbatsov/ruby-style-guide#single-line-blocks)
    end.compact
    ^^^^^^^^^^^
app/controllers/projects_controller.rb:362:27: C: Style/Send: Prefer Object#__send__ or Object#public_send to send. (https://github.com/bbatsov/ruby-style-guide#prefer-public-send)
    @projects = @projects.send params[:status] if
                          ^^^^
app/controllers/projects_controller.rb:401:34: C: Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
    @criteria_level = '0' unless @criteria_level =~ /\A[0-2]\Z/
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/users_controller.rb:93:22: C: Rails/SaveBang: Use destroy! instead of destroy if the return value is not checked. (https://github.com/bbatsov/rails-style-guide#save-bang)
      user_to_delete.destroy
                     ^^^^^^^
app/lib/floss_license_detective.rb:129:11: C: Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
    elsif license =~ /\A[^(]/
          ^^^^^^^^^^^^^^^^^^^
app/lib/subdir_file_contents_detective.rb:60:42: C: Performance/RegexpMatch: Use match? instead of match when MatchData is not used.
        return met_result description if content.match(pattern)
                                         ^^^^^^^^^^^^^^^^^^^^^^
app/models/project.rb:313:11: C: Style/MethodCalledOnDoEndBlock: Avoid chaining a method call on a do...end block. (https://github.com/bbatsov/ruby-style-guide#single-line-blocks)
          end.to_h
          ^^^^^^^^
app/models/project_stat.rb:25:9: C: Style/Send: Prefer Object#__send__ or Object#public_send to send. (https://github.com/bbatsov/ruby-style-guide#prefer-public-send)
        send "percent_ge_#{completion}=", Project.gteq(completion).count
        ^^^^
app/models/user.rb:132:14: C: Style/Send: Prefer Object#__send__ or Object#public_send to send. (https://github.com/bbatsov/ruby-style-guide#prefer-public-send)
    digest = send("#{attribute}_digest")
             ^^^^
app/validators/email_validator.rb:9:15: C: Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
    return if value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/tasks/default.rake:49:5: C: Style/ImplicitRuntimeError: Use raise with an explicit exception class and message, rather than just a message.
    raise 'Must have rbenv or rvm in PATH'
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/tasks/default.rake:450:24: C: Style/Send: Prefer Object#__send__ or Object#public_send to send. (https://github.com/bbatsov/ruby-style-guide#prefer-public-send)
  p ProjectsController.send :send_reminders
                       ^^^^
lib/tasks/default.rake:457:24: C: Style/Send: Prefer Object#__send__ or Object#public_send to send. (https://github.com/bbatsov/ruby-style-guide#prefer-public-send)
  p ProjectsController.send :send_monthly_announcement
                       ^^^^
test/controllers/projects_controller_test.rb:132:15: C: Rails/SaveBang: Use save! instead of save if the return value is not checked. (https://github.com/bbatsov/rails-style-guide#save-bang)
    new_right.save
              ^^^^

162 files inspected, 15 offenses detected
Dans-MacBook-Air:cii-best-practices-badge (master)$ ru
Inspecting 162 files
.........C..C..........C........C.........CCCC................................................................C.....C.............................................
5   Style/Send
4   Performance/RegexpMatch
3   Rails/SaveBang
1   Style/ImplicitRuntimeError
1   Style/MethodCalledOnDoEndBlock
--
14  Total
```